### PR TITLE
在"资源包安装"条目中增加资源包相关科普及下载渠道

### DIFF
--- a/Minecraft/安装光影.xaml
+++ b/Minecraft/安装光影.xaml
@@ -34,7 +34,7 @@
 <local:MyCard Title="获取光影包" Margin="0,0,0,15">
     <StackPanel Margin="25,40,23,15">
         <TextBlock TextWrapping="Wrap" Margin="0,0,0,4"
-                   Text="光影包和材质包类似，是由 Minecraft 玩家创作并分享的，你可以在网上找到其他玩家制作的光影包。很多 Minecraft 交流网站(如 MCBBS)都有专门的光影版块，你可以在这些地方挑选自己喜欢的光影包。OptiFine 也提供了一个分享光影包的网站，在光影设置界面点击光影包文件夹旁的下载按钮即可打开（英文网站）。" />
+                   Text="光影包和资源包类似，是由 Minecraft 玩家创作并分享的，你可以在网上找到其他玩家制作的光影包。很多 Minecraft 交流网站(如 MCBBS)都有专门的光影版块，你可以在这些地方挑选自己喜欢的光影包。OptiFine 也提供了一个分享光影包的网站，在光影设置界面点击光影包文件夹旁的下载按钮即可打开（英文网站）。" />
         <local:MyButton Height="35" HorizontalAlignment="Left" Padding="13,0,13,0"
                    Text="打开 MCBBS 光影板块" EventType="打开网页" EventData="https://www.mcbbs.net/forum.php?mod=forumdisplay&amp;fid=1357" />
     </StackPanel>

--- a/Minecraft/资源包安装.xaml
+++ b/Minecraft/资源包安装.xaml
@@ -1,10 +1,19 @@
 <local:MyHint Margin="0,0,0,15" Text="该帮助页面还需要进一步完善，优化排版与文案。如果你感兴趣也可以来帮帮忙！" IsWarn="False" />
 <!-- 不会XAML，在XiaoFans的帮助文档上稍作修改，可能需要根据规范重新修改表述及格式。 可能仍需继续完善。 -->
 
-<local:MyCard Title="简介" Margin="0,0,0,15">
+<local:MyCard Title="资源包是什么?" Margin="0,0,0,15">
     <StackPanel Margin="25,40,23,15">
 	    <TextBlock TextWrapping="Wrap" Margin="0,0,0,4" LineHeight="17"
-                   Text="在 Minecraft 中有各种各样的资源包，但是很多新手不会安装资源包。这篇帮助就可以让你学会安装资源包。&#xa;本文章假设您已经下载好资源包，如需资源包，请到如 MCBBS，CurseForge 等 Minecraft 资源网站下载。" />
+                   Text="资源包 (Resource Pack) 是 Minecraft 内置的、允许玩家自定义材质、模型、音乐、声音、语言，终末之诗、闪烁标语、鸣谢名单等文本和字体，而不用修改任何代码的功能。" />
+    </StackPanel>
+</local:MyCard>
+
+<local:MyCard Title="获取资源包" Margin="0,0,0,15">
+    <StackPanel Margin="25,40,23,15">
+        <TextBlock TextWrapping="Wrap" Margin="0,0,0,4"
+                   Text="资源包和光影类似，是由 Minecraft 玩家创作并分享的，你可以在网上找到其他玩家制作的光影包。很多 Minecraft 交流网站(如 MCBBS)都有专门的资源包版块，你可以在这些地方挑选自己喜欢的资源包。" />
+        <local:MyButton Height="35" HorizontalAlignment="Left" Padding="13,0,13,0"
+                   Text="打开 MCBBS 资源包板块" EventType="打开网页" EventData="https://www.mcbbs.net/forum-texture-1.html" />
     </StackPanel>
 </local:MyCard>
 


### PR DESCRIPTION
如题。
除了以上更改外
将安装光影条目中的'材质包'修改为标准表述'资源包' 由于改动过小 不再加入作者名单