### PR TITLE
添加B站的Minecraft Wiki

### DIFF
--- a/Minecraft/开发ForgeMod.json
+++ b/Minecraft/开发ForgeMod.json
@@ -1,0 +1,9 @@
+{
+    "__Author__": "mxdyzmx",
+	"Title": "开发基于Forge的Mod",
+	"Description": "开发一个属于自己的Mod!",
+	"Types": ["Minecraft"],
+    "IsEvent": true,
+    "EventType": "打开网页",
+	"EventData": "https://mcforge-cn.readthedocs.io/zh/latest/"
+}

--- a/Minecraft/开发ForgeMod.json
+++ b/Minecraft/开发ForgeMod.json
@@ -1,9 +1,0 @@
-{
-    "__Author__": "mxdyzmx",
-	"Title": "开发基于Forge的Mod",
-	"Description": "开发一个属于自己的Mod!",
-	"Types": ["Minecraft"],
-    "IsEvent": true,
-    "EventType": "打开网页",
-	"EventData": "https://mcforge-cn.readthedocs.io/zh/latest/"
-}

--- a/百科/BiliBili Minecraft Wiki
+++ b/百科/BiliBili Minecraft Wiki
@@ -1,0 +1,10 @@
+{
+	"__Author__": "mxdyzmx",
+	"Title": "国内百科",
+	"Description": "BiliBili Minecraft Wiki：国内由BiliBili假设的镜像百科",
+	"Keywords": "我的世界wikipedia",
+	"Types": ["百科"],
+	"IsEvent": true,
+	"EventType": "打开网页",
+	"EventData": "https://wiki.biligame.com/mc/Minecraft_Wiki"
+}


### PR DESCRIPTION
为了解决有些人连不上https://minecraft.fandom.com/zh/wiki/Minecraft_Wiki的问题 加上了镜像站