### PR TITLE
将所有开头为“cdn.jsdelivr.net”的链接更换至“fastly.jsdelivr.net”，并优化“下载本篇的代码”的下载链接

### DIFF
--- a/Minecraft/安装 Mod.xaml
+++ b/Minecraft/安装 Mod.xaml
@@ -18,10 +18,10 @@
     <StackPanel Margin="25,40,23,15">
         <TextBlock TextWrapping="Wrap" Margin="0,0,0,4" LineHeight="17"
                     Text="1. 打开 PCL2 的自动安装页面，选择想要安装的 Minecraft 版本。然后点击下方的&quot;Forge&quot;按钮即可打开 Forge 版本菜单。"/>
-        <Image HorizontalAlignment="Center" Margin="0,0,0,4" Source="https://cdn.jsdelivr.net/gh/Logic530/PCL2-Help-Image@main/install%20forge.png" />  
+        <Image HorizontalAlignment="Center" Margin="0,0,0,4" Source="https://fastly.jsdelivr.net/gh/Logic530/PCL2-Help-Image@main/install%20forge.png" />  
         <TextBlock TextWrapping="Wrap" Margin="0,0,0,4" LineHeight="17"
                     Text="2. 选择合适的 Forge 版本之后，点击上方的&quot;开始安装&quot;即可安装一个带有 Forge 的 Minecraft 版本。"/>
-        <Image HorizontalAlignment="Center" Margin="0,0,0,4" Source="https://cdn.jsdelivr.net/gh/Logic530/PCL2-Help-Image@main/start%20install%20forge.png" />  
+        <Image HorizontalAlignment="Center" Margin="0,0,0,4" Source="https://fastly.jsdelivr.net/gh/Logic530/PCL2-Help-Image@main/start%20install%20forge.png" />  
         <local:MyHint Margin="0,0,0,15" IsWarn="False" Text="一般来说，只需要选择最新版或推荐版的 Forge 即可。仅在出现 Mod 或服务器等兼容问题时，玩家需要遵循相关指示选择特定的版本。"/>
     </StackPanel>
 </local:MyCard>
@@ -29,13 +29,13 @@
     <StackPanel Margin="25,40,23,15">
         <TextBlock TextWrapping="Wrap" Margin="0,0,0,4" LineHeight="17"
                     Text="1. 打开 PCL2 的自动安装页面，选择想要安装的 Minecraft 版本。然后点击下方的&quot;Fabric&quot;按钮即可打开 Fabric 版本菜单。"/>
-        <Image HorizontalAlignment="Center" Margin="0,0,0,4" Source="https://cdn.jsdelivr.net/gh/Logic530/PCL2-Help-Image@main/install%20fabric.png" />  
+        <Image HorizontalAlignment="Center" Margin="0,0,0,4" Source="https://fastly.jsdelivr.net/gh/Logic530/PCL2-Help-Image@main/install%20fabric.png" />  
         <TextBlock TextWrapping="Wrap" Margin="0,0,0,4" LineHeight="17"
                     Text="2. 选择适合的 Fabric 版本，之后下方会出现 Fabric API 的安装选项，从中选择合适的版本。"/>
-        <Image HorizontalAlignment="Center" Margin="0,0,0,4" Source="https://cdn.jsdelivr.net/gh/Logic530/PCL2-Help-Image@main/install%20fabric%20api.png" />
+        <Image HorizontalAlignment="Center" Margin="0,0,0,4" Source="https://fastly.jsdelivr.net/gh/Logic530/PCL2-Help-Image@main/install%20fabric%20api.png" />
         <TextBlock TextWrapping="Wrap" Margin="0,0,0,4" LineHeight="17"
                     Text="3. 点击上方的&quot;开始安装&quot;即可安装一个带有 Fabric 的 Minecraft 版本。"/>
-        <Image HorizontalAlignment="Center" Margin="0,0,0,4" Source="https://cdn.jsdelivr.net/gh/Logic530/PCL2-Help-Image@main/start%20install%20fabric.png" />
+        <Image HorizontalAlignment="Center" Margin="0,0,0,4" Source="https://fastly.jsdelivr.net/gh/Logic530/PCL2-Help-Image@main/start%20install%20fabric.png" />
         <local:MyHint Margin="0,0,0,15" Text="Fabric API 的安装是必须的。"/>
         <local:MyHint Margin="0,0,0,15" IsWarn="False" Text="一般来说，只需要选择最新版本的 Fabric 和 Fabric API 即可。仅在出现 Mod 或服务器等兼容问题时，玩家需要遵循相关指示选择特定的版本。"/>
     </StackPanel>
@@ -44,11 +44,11 @@
     <StackPanel Margin="25,40,23,15">
         <TextBlock TextWrapping="Wrap" Margin="0,0,0,4" LineHeight="17" Text="PCL2 内置从 CurseForge 下载 Mod 的功能，可以免去从网页下载的种种麻烦。"/>
         <TextBlock TextWrapping="Wrap" Margin="0,0,0,4" LineHeight="17" Text="点击启动器顶部的&quot;下载&quot;按钮，再点击左侧菜单栏中的&quot;Mod&quot;，即可打开 Mod 下载界面。"/>
-        <Image HorizontalAlignment="Center" Source="https://cdn.jsdelivr.net/gh/Logic530/PCL2-Help-Image@main/search%20mod.png" />
+        <Image HorizontalAlignment="Center" Source="https://fastly.jsdelivr.net/gh/Logic530/PCL2-Help-Image@main/search%20mod.png" />
         <TextBlock TextWrapping="Wrap" Margin="0,0,0,4" LineHeight="17" Text="CurseForge 提供了多种搜索 Mod 的方式，玩家可以根据名称、标签或游戏版本搜索 Mod。"/>
         <local:MyHint Margin="0,0,0,15" Text="由于 CurseForge 是一个英文网站，搜索时请尽量使用 Mod 的英文名称。" IsWarn="False" />
         <TextBlock TextWrapping="Wrap" Margin="0,0,0,4" LineHeight="17" Text="搜索完成后，点击想要下载的 Mod 可以打开此 Mod 的页面，玩家可以在此选择需要下载的版本。当前 Mod 需要的前置 Mod 也会在此显示（如果有）。"/>
-        <Image HorizontalAlignment="Center" Source="https://cdn.jsdelivr.net/gh/Logic530/PCL2-Help-Image@main/mod%20version.png" />
+        <Image HorizontalAlignment="Center" Source="https://fastly.jsdelivr.net/gh/Logic530/PCL2-Help-Image@main/mod%20version.png" />
         <local:MyHint Margin="0,0,0,15" Text="选择版本时，请注意选择与 Minecraft 版本匹配的 Mod 版本，PCL2 会在 Mod 版本名称下显示对应的 Minecraft 版本。" IsWarn="False" />
         <local:MyHint Margin="0,0,0,15" Text="分为 Forge 版和 Fabric 版的 Mod，一般会在版本名称中用&quot;forge&quot;或&quot;fabric&quot;进行标注，下载时注意选择对应自己加载器的版本。" IsWarn="False" />
         <TextBlock TextWrapping="Wrap" Margin="0,0,0,4" LineHeight="17" Text="点击需要的 Mod 版本即可开始下载，PCL2 默认将 Mod 下载至启动器主页面选中的游戏版本中，下载完成后即可在此版本中使用下载的 Mod。如有需要，也可在下载对话框中更改下载位置。"/>
@@ -63,9 +63,9 @@
                         Text="打开 MCBBS Mod 分享板块" EventType="打开网页" EventData="https://www.mcbbs.net/forum-mod-1.html" />
         <TextBlock TextWrapping="Wrap" Margin="0,0,0,4" LineHeight="17" Text="下载完成的 Mod 文件的扩展名一般为 .jar（用于老旧加载器 LiteLoader 的 Mod 扩展名为 .litemod），玩家需要将 Mod 文件放入对应游戏版本的 mods 文件夹。" />
         <TextBlock TextWrapping="Wrap" Margin="0,0,0,4" LineHeight="17" Text="PCL2 可以帮助玩家打开 mods 文件夹: 在 PCL2 主页选中需要安装 Mod 的版本，点击&quot;版本设置&quot;，点击左侧菜单中的&quot;Mod 管理&quot;，再点击&quot;打开 Mod 文件夹&quot;即可打开这个游戏版本的 mods 文件夹。将 Mod 文件移动进去即可完成安装。"/>
-        <Image HorizontalAlignment="Center" Source="https://cdn.jsdelivr.net/gh/Logic530/PCL2-Help-Image@main/main%20screen.png"/> 
-        <Image HorizontalAlignment="Center" Source="https://cdn.jsdelivr.net/gh/Logic530/PCL2-Help-Image@main/mod%20list.png"/> 
-        <Image HorizontalAlignment="Center" Source="https://cdn.jsdelivr.net/gh/Logic530/PCL2-Help-Image@main/mods%20folder.png"/> 
+        <Image HorizontalAlignment="Center" Source="https://fastly.jsdelivr.net/gh/Logic530/PCL2-Help-Image@main/main%20screen.png"/> 
+        <Image HorizontalAlignment="Center" Source="https://fastly.jsdelivr.net/gh/Logic530/PCL2-Help-Image@main/mod%20list.png"/> 
+        <Image HorizontalAlignment="Center" Source="https://fastly.jsdelivr.net/gh/Logic530/PCL2-Help-Image@main/mods%20folder.png"/> 
         <local:MyHint Margin="0,0,0,15" Text="在从网站下载 Mod 时，玩家需要注意下载的 Mod 是否与自己的游戏版本以及 Mod 加载器匹配。" IsWarn="False" />
     </StackPanel>
 </local:MyCard>

--- a/Minecraft/微软账号登录失败.xaml
+++ b/Minecraft/微软账号登录失败.xaml
@@ -27,7 +27,7 @@
             <TextBlock Margin="0,10,0,2" LineHeight="17"
                 Text="2. Win10: 转到 WLAN 页面并点击&quot;更改适配器设置&quot;（在右边或者下边）。&#xA; Win11: 点击&quot;高级网络设置&quot;后点击下方的&quot;更多网络适配器选项&quot;。" />
         </Grid>
-        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="https://cdn.jsdelivr.net/gh/Dongyifengs/PCLCDN@main/Minecraft/3.WALN.png" />
+        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="https://fastly.jsdelivr.net/gh/Dongyifengs/PCLCDN@main/Minecraft/3.WALN.png" />
         <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="http://image-pcl2help.test.upcdn.net/MSA-Login/Win11.Settings.NW.SPQ.png" />
 
         <!-- 右键点击你的连接 点击属性 -->
@@ -35,7 +35,7 @@
             <TextBlock Margin="0,10,0,2" LineHeight="17"
                 Text="3. 右键点击你的连接，点击属性。" />
         </Grid>
-        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="https://cdn.jsdelivr.net/gh/Dongyifengs/PCLCDN@main/Minecraft/4.R.png" />
+        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="https://fastly.jsdelivr.net/gh/Dongyifengs/PCLCDN@main/Minecraft/4.R.png" />
 
         <Grid>
             <TextBlock Margin="0,10,0,2" LineHeight="17"
@@ -65,7 +65,7 @@
             <TextBlock Margin="0,10,0,2" LineHeight="17"
                 Text="2. 按下键盘上的 Windows + R 键，打开运行界面，输入 services.msc 打开服务管理程序。" />
                         </Grid>
-        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="https://cdn.jsdelivr.net/gh/Dongyifengs/PCLCDN@main/Minecraft/10.Service.png" />
+        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="https://fastly.jsdelivr.net/gh/Dongyifengs/PCLCDN@main/Minecraft/10.Service.png" />
         <local:MyButton MinWidth="170" Height="35" Padding="10,0" Margin="0,5,20,8" HorizontalAlignment="Left"
         Text="复制 services.msc 命令" EventType="复制文本" EventData="services.msc" />
 
@@ -74,7 +74,7 @@
             <TextBlock Margin="0,10,0,2" LineHeight="17"
                 Text="3. 找到&quot;Microsoft (R) 诊断中心标准收集器服务&quot;，右键点击属性，改成手动，开启服务。" />
                         </Grid>
-        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="https://cdn.jsdelivr.net/gh/Dongyifengs/PCLCDN@main/Minecraft/11.Microsoft(R).png" />
+        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="https://fastly.jsdelivr.net/gh/Dongyifengs/PCLCDN@main/Minecraft/11.Microsoft(R).png" />
 
         <Grid>
             <TextBlock Margin="0,10,0,2" LineHeight="17"
@@ -87,7 +87,7 @@
             <TextBlock Margin="0,10,0,2" LineHeight="17"
                 Text="5. Win10: 转到 WLAN 页面并点击&quot;更改适配器设置&quot;（在右边或者下边）。&#xA; Win11: 点击&quot;高级网络设置&quot;后点击下方的&quot;更多网络适配器选项&quot;。" />
         </Grid>
-        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="https://cdn.jsdelivr.net/gh/Dongyifengs/PCLCDN@main/Minecraft/3.WALN.png" />
+        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="https://fastly.jsdelivr.net/gh/Dongyifengs/PCLCDN@main/Minecraft/3.WALN.png" />
         <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="http://image-pcl2help.test.upcdn.net/MSA-Login/Win11.Settings.NW.SPQ.png" />
 
         <!-- 右键点击你的连接 点击属性 -->
@@ -95,7 +95,7 @@
             <TextBlock Margin="0,10,0,2" LineHeight="17"
                 Text="6. 右键选择你的连接，点击属性。" />
         </Grid>
-        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="https://cdn.jsdelivr.net/gh/Dongyifengs/PCLCDN@main/Minecraft/4.R.png" />
+        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="https://fastly.jsdelivr.net/gh/Dongyifengs/PCLCDN@main/Minecraft/4.R.png" />
 
         <Grid>
             <TextBlock Margin="0,10,0,2" LineHeight="17"

--- a/Minecraft/设置分配内存大小.xaml
+++ b/Minecraft/设置分配内存大小.xaml
@@ -33,10 +33,10 @@
 		<local:MyHint Margin="0,-5,0,15" Text="请注意，修改 PCL 2 的全局配置将影响所有依赖 PCL 2 启动的游戏版本。"/>
         <TextBlock Margin="0,0,0,4" LineHeight="20"
                    Text="1. 打开您的 PCL 2 启动器，在主页点击上方的“设置”选单。" />
-        <Image HorizontalAlignment="Center" Source="https://cdn.jsdelivr.net/gh/Dongyifengs/PCLCDN@main/Setting.png" />             
+        <Image HorizontalAlignment="Center" Source="https://fastly.jsdelivr.net/gh/Dongyifengs/PCLCDN@main/Setting.png" />             
         <TextBlock Margin="0,4,0,4" LineHeight="20"
                    Text="2. 点击左侧的“游戏”选项卡，向下翻找，找到“游戏内存”选项卡。" />
-        <Image HorizontalAlignment="Center" Source="https://cdn.jsdelivr.net/gh/Dongyifengs/PCLCDN@main/Storage.png" />
+        <Image HorizontalAlignment="Center" Source="https://fastly.jsdelivr.net/gh/Dongyifengs/PCLCDN@main/Storage.png" />
         <TextBlock Margin="0,4,0,4" LineHeight="20"
                    Text="3. 选择“自定义”，此时拖动圆点即可手动调整全局内存。" />
     </StackPanel>

--- a/个性化/XAML 格式.xaml
+++ b/个性化/XAML 格式.xaml
@@ -12,7 +12,7 @@
         <TextBlock Margin="0,0,0,4" FontSize="13" HorizontalAlignment="Center" Foreground="{DynamicResource ColorBrush1}"
                    Text="本篇简单介绍了在 PCL2 中使用 XAML 进行自定义页面的相关语法，由于内容繁多，建议下载本篇代码参考学习。" />
         <local:MyButton Margin="0,8,0,8" Width="200" Height="35"
-                   Text="下载本篇的代码" EventType="下载文件" EventData="https://cdn.jsdelivr.net/gh//LTCatt@latest/PCL2Help/个性化/XAML%20格式.xaml" ToolTip="下载本篇的代码" />
+                   Text="下载本篇的代码" EventType="下载文件" EventData="https://fastly.jsdelivr.net/gh/LTCatt/PCL2Help/个性化/XAML%20格式.xaml" ToolTip="下载本篇的代码" />
     </StackPanel>
 </local:MyCard>
 

--- a/启动器/LittleSkin 外置登录使用教程.xaml
+++ b/启动器/LittleSkin 外置登录使用教程.xaml
@@ -19,23 +19,23 @@
         <TextBlock Margin="0,30,0,0" Text="1. 前往 https://littleskin.cn/auth/register 注册一个 LittleSkin 账号。" />
         <local:MyButton Margin="0,10,0,0" MinWidth="140" Padding="13,0" HorizontalAlignment="Left" Height="35" Text="打开 LittleSkin 注册界面" EventType="打开网页" EventData="https://littleskin.cn/auth/register" />
 
-        <Image Margin="0,10,0,0" Height="360" HorizontalAlignment="Left" Source ="https://cdn.jsdelivr.net/gh/bling-yshs/ys_tuchuang@main//img1.png" />
+        <Image Margin="0,10,0,0" Height="360" HorizontalAlignment="Left" Source ="https://fastly.jsdelivr.net/gh/bling-yshs/ys_tuchuang@main//img1.png" />
 
         <TextBlock Margin="0,50,0,0" Text="2. 注册完以后，进入 https://littleskin.cn/user 点击左侧“角色管理”，再点击“添加新角色。”" />
         <local:MyButton Margin="0,10,0,0" MinWidth="140" Padding="13,0" HorizontalAlignment="Left" Height="35" Text="打开 LittleSkin 用户中心" EventType="打开网页" EventData="https://littleskin.cn/user" />
-        <Image Margin="0,10,0,0" Height="360" HorizontalAlignment="Left" Source="https://cdn.jsdelivr.net/gh/bling-yshs/ys_tuchuang@main//img2.png" />
+        <Image Margin="0,10,0,0" Height="360" HorizontalAlignment="Left" Source="https://fastly.jsdelivr.net/gh/bling-yshs/ys_tuchuang@main//img2.png" />
 
         <TextBlock Margin="0,50,0,0" Text="3. 在弹出的窗口内输入角色名(这将会成为联机时的ID)，填写完成后点击“确定”。" />
-        <Image Margin="0,20,0,0" Height="360" HorizontalAlignment="Left" Source="https://cdn.jsdelivr.net/gh/bling-yshs/ys_tuchuang@main//img3.png" />
+        <Image Margin="0,20,0,0" Height="360" HorizontalAlignment="Left" Source="https://fastly.jsdelivr.net/gh/bling-yshs/ys_tuchuang@main//img3.png" />
 
         <TextBlock Margin="0,50,0,0" Text="4. 打开 PCL2 启动器，点击左下角的“版本选择”。" />
-        <Image Margin="0,20,0,0" Height="360" HorizontalAlignment="Left" Source="https://cdn.jsdelivr.net/gh/bling-yshs/ys_tuchuang@main//img4.png" />
+        <Image Margin="0,20,0,0" Height="360" HorizontalAlignment="Left" Source="https://fastly.jsdelivr.net/gh/bling-yshs/ys_tuchuang@main//img4.png" />
 
         <TextBlock Margin="0,50,0,0" Text="5. 右键点击将要联机的游戏版本。" />
-        <Image Margin="0,20,0,0" Height="360" HorizontalAlignment="Left"  Source ="https://cdn.jsdelivr.net/gh/bling-yshs/ys_tuchuang@main//img5.png" />
+        <Image Margin="0,20,0,0" Height="360" HorizontalAlignment="Left"  Source ="https://fastly.jsdelivr.net/gh/bling-yshs/ys_tuchuang@main//img5.png" />
 
         <TextBlock Margin="0,50,0,0" Text="6. 点击左侧“设置”选项，并滑动到页面底部，登录方式选择“第三方登录：Authlib-Injector”。" />
-        <Image Margin="0,20,0,0" Height="360" HorizontalAlignment="Left" Source ="https://cdn.jsdelivr.net/gh/bling-yshs/ys_tuchuang@main//img6.png" />
+        <Image Margin="0,20,0,0" Height="360" HorizontalAlignment="Left" Source ="https://fastly.jsdelivr.net/gh/bling-yshs/ys_tuchuang@main//img6.png" />
 
         <TextBlock Margin="0,50,0,0" Text="7. 按要求填写信息。" />
         <TextBlock Background="#ddff95" Padding="5,5,5,5" Margin="0,10,0,0" Text="   认证服务器 https://littleskin.cn/api/yggdrasil" />
@@ -44,10 +44,10 @@
         <local:MyButton Margin="0,10,0,0" Width="160" Height="35" HorizontalAlignment="Left" Padding="13,0,13,0" Text="复制“注册链接”网址" EventType="复制文本" EventData="https://littleskin.cn/auth/register" />
         <TextBlock Background="#f1b8f1" Padding="5,5,5,5" Margin="0,10,0,0" Text="   服务器名称 任意" />
         <TextBlock Background="#f1ccb8" Padding="5,5,5,5" Margin="0,10,0,0" Text="   自动进入服务器 留空" />
-        <Image Margin="0,20,0,0" Height="360" HorizontalAlignment="Left" Source ="https://cdn.jsdelivr.net/gh/bling-yshs/ys_tuchuang@main//img7.png" />
+        <Image Margin="0,20,0,0" Height="360" HorizontalAlignment="Left" Source ="https://fastly.jsdelivr.net/gh/bling-yshs/ys_tuchuang@main//img7.png" />
 
         <TextBlock Margin="0,50,0,0" Text="8.填写完成后返回 PCL2 启动界面，输入 LittleSkin 网站的账号以及密码，启动游戏后即可登录。" />
-        <Image Margin="0,20,0,0" Height="360" HorizontalAlignment="Left" Source ="https://cdn.jsdelivr.net/gh/bling-yshs/ys_tuchuang@main//img8.png" />
+        <Image Margin="0,20,0,0" Height="360" HorizontalAlignment="Left" Source ="https://fastly.jsdelivr.net/gh/bling-yshs/ys_tuchuang@main//img8.png" />
         <local:MyHint Margin="0,20,0,0" Text="使用 LittleSkin 外置登录后仍无法进入正版服务器。您只能进入离线模式服务器、使用外置登录的服务器和局域网联机。" IsWarn="True" />
     </StackPanel>
 </local:MyCard>

--- a/启动器/指定登录方式.xaml
+++ b/启动器/指定登录方式.xaml
@@ -11,16 +11,16 @@
 <local:MyCard Title="教程">
     <StackPanel Margin="25,40,23,15">
         <TextBlock Margin="0,10,0,0" Text="1. 点击下方“版本选择”。" />
-        <Image Height="360" Margin="0,20,0,0" HorizontalAlignment="Left" Source="https://cdn.jsdelivr.net/gh/bling-yshs/ys_tuchuang@main//imgdl1.png" />
+        <Image Height="360" Margin="0,20,0,0" HorizontalAlignment="Left" Source="https://fastly.jsdelivr.net/gh/bling-yshs/ys_tuchuang@main//imgdl1.png" />
 
         <TextBlock Margin="0,50,0,0" Text="2. 右键点击需要修改的游戏版本。" />
-        <Image Height="360" Margin="0,20,0,0" HorizontalAlignment="Left" Source="https://cdn.jsdelivr.net/gh/bling-yshs/ys_tuchuang@main//imgdl2.png" />
+        <Image Height="360" Margin="0,20,0,0" HorizontalAlignment="Left" Source="https://fastly.jsdelivr.net/gh/bling-yshs/ys_tuchuang@main//imgdl2.png" />
 
         <TextBlock Margin="0,50,0,0" Text="3. 点击左侧“设置”按钮。" />
-        <Image Height="360" Margin="0,20,0,0" HorizontalAlignment="Left" Source="https://cdn.jsdelivr.net/gh/bling-yshs/ys_tuchuang@main//imgdl3.png" />
+        <Image Height="360" Margin="0,20,0,0" HorizontalAlignment="Left" Source="https://fastly.jsdelivr.net/gh/bling-yshs/ys_tuchuang@main//imgdl3.png" />
         
         <TextBlock Margin="0,50,0,0" Text="4. 滑动至下方“服务器选项”，选择登录方式即可切换。" />
-        <Image Height="360" Margin="0,20,0,0" HorizontalAlignment="Left" Source="https://cdn.jsdelivr.net/gh/bling-yshs/ys_tuchuang@main//imgdl4.png" />
+        <Image Height="360" Margin="0,20,0,0" HorizontalAlignment="Left" Source="https://fastly.jsdelivr.net/gh/bling-yshs/ys_tuchuang@main//imgdl4.png" />
     </StackPanel>
 </local:MyCard>
 


### PR DESCRIPTION
更换至“fastly.jsdelivr.net”的原因是，最近“cdn.jsdelivr.net”遭到DNS污染，但“fastly.jsdelivr.net”却没有，所以就换掉了