### PR TITLE
将图床由其它第三方图床与 jsDelivr 更换为 Backblaze B2 + Cloudflare

### DIFF
--- a/Minecraft/安装 Mod.xaml
+++ b/Minecraft/安装 Mod.xaml
@@ -18,10 +18,10 @@
     <StackPanel Margin="25,40,23,15">
         <TextBlock TextWrapping="Wrap" Margin="0,0,0,4" LineHeight="17"
                     Text="1. 打开 PCL2 的自动安装页面，选择想要安装的 Minecraft 版本。然后点击下方的&quot;Forge&quot;按钮即可打开 Forge 版本菜单。"/>
-        <Image HorizontalAlignment="Center" Margin="0,0,0,4" Source="https://cdn.jsdelivr.net/gh/Logic530/PCL2-Help-Image@main/install%20forge.png" />  
+        <Image HorizontalAlignment="Center" Margin="0,0,0,4" Source="https://resources.cakeskin.tk/file/pcl2-image/mods/install%20forge.png" />  
         <TextBlock TextWrapping="Wrap" Margin="0,0,0,4" LineHeight="17"
                     Text="2. 选择合适的 Forge 版本之后，点击上方的&quot;开始安装&quot;即可安装一个带有 Forge 的 Minecraft 版本。"/>
-        <Image HorizontalAlignment="Center" Margin="0,0,0,4" Source="https://cdn.jsdelivr.net/gh/Logic530/PCL2-Help-Image@main/start%20install%20forge.png" />  
+        <Image HorizontalAlignment="Center" Margin="0,0,0,4" Source="https://resources.cakeskin.tk/file/pcl2-image/mods/start%20install%20forge.png" />  
         <local:MyHint Margin="0,0,0,15" IsWarn="False" Text="一般来说，只需要选择最新版或推荐版的 Forge 即可。仅在出现 Mod 或服务器等兼容问题时，玩家需要遵循相关指示选择特定的版本。"/>
     </StackPanel>
 </local:MyCard>
@@ -29,13 +29,13 @@
     <StackPanel Margin="25,40,23,15">
         <TextBlock TextWrapping="Wrap" Margin="0,0,0,4" LineHeight="17"
                     Text="1. 打开 PCL2 的自动安装页面，选择想要安装的 Minecraft 版本。然后点击下方的&quot;Fabric&quot;按钮即可打开 Fabric 版本菜单。"/>
-        <Image HorizontalAlignment="Center" Margin="0,0,0,4" Source="https://cdn.jsdelivr.net/gh/Logic530/PCL2-Help-Image@main/install%20fabric.png" />  
+        <Image HorizontalAlignment="Center" Margin="0,0,0,4" Source="https://resources.cakeskin.tk/file/pcl2-image/mods/install%20fabric.png" />  
         <TextBlock TextWrapping="Wrap" Margin="0,0,0,4" LineHeight="17"
                     Text="2. 选择适合的 Fabric 版本，之后下方会出现 Fabric API 的安装选项，从中选择合适的版本。"/>
-        <Image HorizontalAlignment="Center" Margin="0,0,0,4" Source="https://cdn.jsdelivr.net/gh/Logic530/PCL2-Help-Image@main/install%20fabric%20api.png" />
+        <Image HorizontalAlignment="Center" Margin="0,0,0,4" Source="https://resources.cakeskin.tk/file/pcl2-image/mods/install%20fabric%20api.png" />
         <TextBlock TextWrapping="Wrap" Margin="0,0,0,4" LineHeight="17"
                     Text="3. 点击上方的&quot;开始安装&quot;即可安装一个带有 Fabric 的 Minecraft 版本。"/>
-        <Image HorizontalAlignment="Center" Margin="0,0,0,4" Source="https://cdn.jsdelivr.net/gh/Logic530/PCL2-Help-Image@main/start%20install%20fabric.png" />
+        <Image HorizontalAlignment="Center" Margin="0,0,0,4" Source="https://resources.cakeskin.tk/file/pcl2-image/mods/start%20install%20fabric.png" />
         <local:MyHint Margin="0,0,0,15" Text="Fabric API 的安装是必须的。"/>
         <local:MyHint Margin="0,0,0,15" IsWarn="False" Text="一般来说，只需要选择最新版本的 Fabric 和 Fabric API 即可。仅在出现 Mod 或服务器等兼容问题时，玩家需要遵循相关指示选择特定的版本。"/>
     </StackPanel>
@@ -44,11 +44,11 @@
     <StackPanel Margin="25,40,23,15">
         <TextBlock TextWrapping="Wrap" Margin="0,0,0,4" LineHeight="17" Text="PCL2 内置从 CurseForge 下载 Mod 的功能，可以免去从网页下载的种种麻烦。"/>
         <TextBlock TextWrapping="Wrap" Margin="0,0,0,4" LineHeight="17" Text="点击启动器顶部的&quot;下载&quot;按钮，再点击左侧菜单栏中的&quot;Mod&quot;，即可打开 Mod 下载界面。"/>
-        <Image HorizontalAlignment="Center" Source="https://cdn.jsdelivr.net/gh/Logic530/PCL2-Help-Image@main/search%20mod.png" />
+        <Image HorizontalAlignment="Center" Source="https://resources.cakeskin.tk/file/pcl2-image/mods/search%20mod.png" />
         <TextBlock TextWrapping="Wrap" Margin="0,0,0,4" LineHeight="17" Text="CurseForge 提供了多种搜索 Mod 的方式，玩家可以根据名称、标签或游戏版本搜索 Mod。"/>
         <local:MyHint Margin="0,0,0,15" Text="由于 CurseForge 是一个英文网站，搜索时请尽量使用 Mod 的英文名称。" IsWarn="False" />
         <TextBlock TextWrapping="Wrap" Margin="0,0,0,4" LineHeight="17" Text="搜索完成后，点击想要下载的 Mod 可以打开此 Mod 的页面，玩家可以在此选择需要下载的版本。当前 Mod 需要的前置 Mod 也会在此显示（如果有）。"/>
-        <Image HorizontalAlignment="Center" Source="https://cdn.jsdelivr.net/gh/Logic530/PCL2-Help-Image@main/mod%20version.png" />
+        <Image HorizontalAlignment="Center" Source="https://resources.cakeskin.tk/file/pcl2-image/mods/mod%20version.png" />
         <local:MyHint Margin="0,0,0,15" Text="选择版本时，请注意选择与 Minecraft 版本匹配的 Mod 版本，PCL2 会在 Mod 版本名称下显示对应的 Minecraft 版本。" IsWarn="False" />
         <local:MyHint Margin="0,0,0,15" Text="分为 Forge 版和 Fabric 版的 Mod，一般会在版本名称中用&quot;forge&quot;或&quot;fabric&quot;进行标注，下载时注意选择对应自己加载器的版本。" IsWarn="False" />
         <TextBlock TextWrapping="Wrap" Margin="0,0,0,4" LineHeight="17" Text="点击需要的 Mod 版本即可开始下载，PCL2 默认将 Mod 下载至启动器主页面选中的游戏版本中，下载完成后即可在此版本中使用下载的 Mod。如有需要，也可在下载对话框中更改下载位置。"/>
@@ -63,9 +63,9 @@
                         Text="打开 MCBBS Mod 分享板块" EventType="打开网页" EventData="https://www.mcbbs.net/forum-mod-1.html" />
         <TextBlock TextWrapping="Wrap" Margin="0,0,0,4" LineHeight="17" Text="下载完成的 Mod 文件的扩展名一般为 .jar（用于老旧加载器 LiteLoader 的 Mod 扩展名为 .litemod），玩家需要将 Mod 文件放入对应游戏版本的 mods 文件夹。" />
         <TextBlock TextWrapping="Wrap" Margin="0,0,0,4" LineHeight="17" Text="PCL2 可以帮助玩家打开 mods 文件夹: 在 PCL2 主页选中需要安装 Mod 的版本，点击&quot;版本设置&quot;，点击左侧菜单中的&quot;Mod 管理&quot;，再点击&quot;打开 Mod 文件夹&quot;即可打开这个游戏版本的 mods 文件夹。将 Mod 文件移动进去即可完成安装。"/>
-        <Image HorizontalAlignment="Center" Source="https://cdn.jsdelivr.net/gh/Logic530/PCL2-Help-Image@main/main%20screen.png"/> 
-        <Image HorizontalAlignment="Center" Source="https://cdn.jsdelivr.net/gh/Logic530/PCL2-Help-Image@main/mod%20list.png"/> 
-        <Image HorizontalAlignment="Center" Source="https://cdn.jsdelivr.net/gh/Logic530/PCL2-Help-Image@main/mods%20folder.png"/> 
+        <Image HorizontalAlignment="Center" Source="https://resources.cakeskin.tk/file/pcl2-image/mods/main%20screen.png"/> 
+        <Image HorizontalAlignment="Center" Source="https://resources.cakeskin.tk/file/pcl2-image/mods/mod%20list.png"/> 
+        <Image HorizontalAlignment="Center" Source="https://resources.cakeskin.tk/file/pcl2-image/mods/mods%20folder.png"/> 
         <local:MyHint Margin="0,0,0,15" Text="在从网站下载 Mod 时，玩家需要注意下载的 Mod 是否与自己的游戏版本以及 Mod 加载器匹配。" IsWarn="False" />
     </StackPanel>
 </local:MyCard>

--- a/Minecraft/安装世界.xaml
+++ b/Minecraft/安装世界.xaml
@@ -23,18 +23,18 @@
     <StackPanel Margin="25,40,23,15">
         <TextBlock TextWrapping="Wrap" Margin="0,0,0,4"
                    Text="世界下载完成后需要导入方可在游戏中使用。导入世界只需将您得到的地图文件夹放入 .minecraft/saves 文件夹即可。&#xa;有些地图的文件夹根目录有 resources.zip 文件，这是地图自带的材质包，您可以参考“安装资源包”教程进行安装。" />
-                   <Image HorizontalAlignment="Center" Source="http://image-pcl2help.test.upcdn.net/saves/explorer-saves-folder.png" />
-                   <Image HorizontalAlignment="Center" Source="http://image-pcl2help.test.upcdn.net/saves/explorer-import-worlds.png" />
+                   <Image HorizontalAlignment="Center" Source="https://resources.cakeskin.tk/file/pcl2-image/saves/explorer-saves-folder.png" />
+                   <Image HorizontalAlignment="Center" Source="https://resources.cakeskin.tk/file/pcl2-image/saves/explorer-import-worlds.png" />
         <local:MyHint Margin="0,0,0,15" Text="注意: 大部分地图下载下来后为压缩文件(.rar / .zip / .7z)，您需要解压后放入 saves 文件夹。" IsWarn="False"/>
         <TextBlock TextWrapping="Wrap" Margin="0,0,0,4"
                     Text="如果您开启了版本隔离，则您需要在 PCL2 中选中您需要安装世界的版本，点击右侧的小齿轮(或在主页点击“版本设置”)，然后点击“打开版本文件夹”，找到 .minecraft/saves 文件夹再将世界放入此文件夹。"/>
-                    <Image HorizontalAlignment="Center" Source="http://image-pcl2help.test.upcdn.net/saves/pcl2-choose-version-to-open-settings.png"/>
-                    <Image HorizontalAlignment="Center" Source="http://image-pcl2help.test.upcdn.net/saves/pcl2-find-version-settings.png"/>
-                    <Image HorizontalAlignment="Center" Source="http://image-pcl2help.test.upcdn.net/saves/pcl2-open-version-folder.png"/>
-                    <Image HorizontalAlignment="Center" Source="http://image-pcl2help.test.upcdn.net/saves/explorer-other-saves.png"/>
+                    <Image HorizontalAlignment="Center" Source="https://resources.cakeskin.tk/file/pcl2-image/saves/pcl2-choose-version-to-open-settings.png"/>
+                    <Image HorizontalAlignment="Center" Source="https://resources.cakeskin.tk/file/pcl2-image/saves/pcl2-find-version-settings.png"/>
+                    <Image HorizontalAlignment="Center" Source="https://resources.cakeskin.tk/file/pcl2-image/saves/pcl2-open-version-folder.png"/>
+                    <Image HorizontalAlignment="Center" Source="https://resources.cakeskin.tk/file/pcl2-image/saves/explorer-other-saves.png"/>
         <TextBlock TextWrapping="Wrap" Margin="0,0,0,4"
                     Text="在 PCL2 中选中您刚才导入世界的版本，点击启动，点击“单人游戏”，找到您刚刚导入的存档(一般与文件夹同名)，双击以游玩。"/>
-                    <Image HorizontalAlignment="Center" Source="http://image-pcl2help.test.upcdn.net/saves/minecraft-play.png"/>
+                    <Image HorizontalAlignment="Center" Source="https://resources.cakeskin.tk/file/pcl2-image/saves/minecraft-play.png"/>
     </StackPanel>
 </local:MyCard>
 

--- a/Minecraft/安装光影.xaml
+++ b/Minecraft/安装光影.xaml
@@ -17,7 +17,7 @@
     <StackPanel Margin="25,40,23,15">
         <TextBlock TextWrapping="Wrap" Margin="0,0,0,4"
                    Text="如果你选择使用 OptiFine，PCL2 可以为下载的 Minecraft 版本自动安装 OptiFine，使用自动安装功能时展开“OptiFine”菜单，选择需要的版本即可。" />
-        <Image HorizontalAlignment="Center" Source="https://pic.liesio.com/2021/07/19/48304d59afe03.png" />
+        <Image HorizontalAlignment="Center" Source="hhttps://resources.cakeskin.tk/file/pcl2-image/Install-Shaders/Install-OptiFine.png" />
         <local:MyHint Margin="0,0,0,7" IsWarn="False"
                    Text="OptiFine 可以通过安装 OptiFabric Mod 兼容 Fabric 加载器。关于安装 OptiFabric 的详细说明，请查看请查看帮助“安装 Mod”。" />
     </StackPanel>
@@ -56,8 +56,7 @@
                    Text="有时光影包的作者会依据光影包对电脑性能的需求高低制作多个版本的光影包，并打包成一个压缩包方便玩家下载，此时则需要将大压缩包中的每个光影包提取出来才能使用。" />
         <TextBlock TextWrapping="Wrap" Margin="0,0,0,4"
                    Text="导入完成后，在光影设置界面（选项-视频设置-光影…）可以看到已经导入的光影包，点击即可启用。" />
-        <Image HorizontalAlignment="Center" Source="https://pic.liesio.com/2021/07/19/f300670c6071d.png" />
-        <Image HorizontalAlignment="Center" Source="https://s4.ax1x.com/2022/02/03/HVq7jJ.png" />
+        <Image HorizontalAlignment="Center" Source="https://resources.cakeskin.tk/file/pcl2-image/Install-Shaders/Shader-List.png" />
         <TextBlock TextWrapping="Wrap" Margin="0,0,0,4"
                    Text="你还可以在光影设置界面对光影的效果做进一步调整，右侧列出的是 OptiFine 提供的通用选项，点击右下角的光影设置可以打开当前光影包的专有选项，以便对光影的效果作出更多调整。" />
     </StackPanel>

--- a/Minecraft/微软账号登录失败.xaml
+++ b/Minecraft/微软账号登录失败.xaml
@@ -20,29 +20,29 @@
             <TextBlock Margin="0,10,0,2" LineHeight="17"
                 Text="1. 在任务栏上找到对应网络状态的图标，右键点击此图标后点击&quot;网络和 Internet 设置&quot;。" />
         </Grid>
-        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="http://image-pcl2help.test.upcdn.net/MSA-Login/Taskbar.NI.Settings.png" />
+        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="https://resources.cakeskin.tk/file/pcl2-image/MSA-Login/Taskbar.NI.Settings.png" />
 
         <!-- 更改适配器设置 -->
         <Grid>
             <TextBlock Margin="0,10,0,2" LineHeight="17"
                 Text="2. Win10: 转到 WLAN 页面并点击&quot;更改适配器设置&quot;（在右边或者下边）。&#xA; Win11: 点击&quot;高级网络设置&quot;后点击下方的&quot;更多网络适配器选项&quot;。" />
         </Grid>
-        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="https://cdn.jsdelivr.net/gh/Dongyifengs/PCLCDN@main/Minecraft/3.WALN.png" />
-        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="http://image-pcl2help.test.upcdn.net/MSA-Login/Win11.Settings.NW.SPQ.png" />
+        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="https://resources.cakeskin.tk/file/pcl2-image/MSA-Login/3.WALN.png" />
+        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="https://resources.cakeskin.tk/file/pcl2-image/MSA-Login/Win11.Settings.NW.SPQ.png" />
 
         <!-- 右键点击你的连接 点击属性 -->
         <Grid>
             <TextBlock Margin="0,10,0,2" LineHeight="17"
                 Text="3. 右键点击你的连接，点击属性。" />
         </Grid>
-        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="https://cdn.jsdelivr.net/gh/Dongyifengs/PCLCDN@main/Minecraft/4.R.png" />
+        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="https://resources.cakeskin.tk/file/pcl2-image/MSA-Login/4.R.png" />
 
         <Grid>
             <TextBlock Margin="0,10,0,2" LineHeight="17"
                 Text="4. 双击“Internet 协议版本 4 (TCP/IPv4)”，点击使用下面的 DNS 服务器地址，在“首选 DNS 服务器”内填写“223.5.5.5”，在“备用 DNS 服务器”内填写“223.6.6.6”，您也可选择其他国内知名 DNS 提供商提供的 DNS (如 DNSPod)。保存后按住键盘上的 Windows 键 + R 键，输入“ipconfig /flushdns”以刷新 DNS 缓存，接着再次进入 PCL2 启动游戏即可正常登录。" />
         </Grid>
         <!-- 此处原 DNS 为微软公用 DNS，鉴于此 DNS 在中国大陆内使用情况不佳，更改为阿里云 DNS -->
-        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="http://image-pcl2help.test.upcdn.net/MSA-Login/ControlPanel.DNS.Settings.png" />
+        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="https://resources.cakeskin.tk/file/pcl2-image/MSA-Login/ControlPanel.DNS.Settings.png" />
         <local:MyButton MinWidth="170" Height="35" Padding="10,0" Margin="0,5,20,8" HorizontalAlignment="Left"
         Text="复制 ipconfig /flushdns 命令" EventType="复制文本" EventData="ipconfig /flushdns" />
 
@@ -65,7 +65,7 @@
             <TextBlock Margin="0,10,0,2" LineHeight="17"
                 Text="2. 按下键盘上的 Windows + R 键，打开运行界面，输入 services.msc 打开服务管理程序。" />
                         </Grid>
-        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="https://cdn.jsdelivr.net/gh/Dongyifengs/PCLCDN@main/Minecraft/10.Service.png" />
+        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="https://resources.cakeskin.tk/file/pcl2-image/MSA-Login/10.Service.png" />
         <local:MyButton MinWidth="170" Height="35" Padding="10,0" Margin="0,5,20,8" HorizontalAlignment="Left"
         Text="复制 services.msc 命令" EventType="复制文本" EventData="services.msc" />
 
@@ -74,35 +74,35 @@
             <TextBlock Margin="0,10,0,2" LineHeight="17"
                 Text="3. 找到&quot;Microsoft (R) 诊断中心标准收集器服务&quot;，右键点击属性，改成手动，开启服务。" />
                         </Grid>
-        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="https://cdn.jsdelivr.net/gh/Dongyifengs/PCLCDN@main/Minecraft/11.Microsoft(R).png" />
+        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="https://resources.cakeskin.tk/file/pcl2-image/MSA-Login/11.Microsoft(R).png" />
 
         <Grid>
             <TextBlock Margin="0,10,0,2" LineHeight="17"
                 Text="4. 在任务栏上找到对应网络状态的图标，右键点击此图标后&quot;网络和 Internet 设置&quot;。" />
         </Grid>
-        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="http://image-pcl2help.test.upcdn.net/MSA-Login/Taskbar.NI.Settings.png" />
+        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="https://resources.cakeskin.tk/file/pcl2-image/MSA-Login/Taskbar.NI.Settings.png" />
 
         <!-- 更改适配器设置 -->
         <Grid>
             <TextBlock Margin="0,10,0,2" LineHeight="17"
                 Text="5. Win10: 转到 WLAN 页面并点击&quot;更改适配器设置&quot;（在右边或者下边）。&#xA; Win11: 点击&quot;高级网络设置&quot;后点击下方的&quot;更多网络适配器选项&quot;。" />
         </Grid>
-        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="https://cdn.jsdelivr.net/gh/Dongyifengs/PCLCDN@main/Minecraft/3.WALN.png" />
-        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="http://image-pcl2help.test.upcdn.net/MSA-Login/Win11.Settings.NW.SPQ.png" />
+        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="https://resources.cakeskin.tk/file/pcl2-image/MSA-Login/3.WALN.png" />
+        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="https://resources.cakeskin.tk/file/pcl2-image/MSA-Login/Win11.Settings.NW.SPQ.png" />
 
         <!-- 右键点击你的连接 点击属性 -->
         <Grid>
             <TextBlock Margin="0,10,0,2" LineHeight="17"
                 Text="6. 右键选择你的连接，点击属性。" />
         </Grid>
-        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="https://cdn.jsdelivr.net/gh/Dongyifengs/PCLCDN@main/Minecraft/4.R.png" />
+        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="https://resources.cakeskin.tk/file/pcl2-image/MSA-Login/4.R.png" />
 
         <Grid>
             <TextBlock Margin="0,10,0,2" LineHeight="17"
                 Text="4. 双击“Internet 协议版本 4 (TCP/IPv4)”，点击使用下面的 DNS 服务器地址，在“首选 DNS 服务器”内填写“223.5.5.5”，在“备用 DNS 服务器”内填写“223.6.6.6”，您也可选择其他国内知名 DNS 提供商提供的 DNS (如 DNSPod)。保存后按住键盘上的 Windows 键 + R 键，输入“ipconfig /flushdns”以刷新 DNS 缓存，接着再次进入 PCL2 启动游戏即可正常登录。" />
         </Grid>
         <!-- 此处原 DNS 为微软公用 DNS，鉴于此 DNS 在中国大陆内使用情况不佳，更改为阿里云 DNS -->
-        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="http://image-pcl2help.test.upcdn.net/MSA-Login/ControlPanel.DNS.Settings.png" />
+        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="https://resources.cakeskin.tk/file/pcl2-image/MSA-Login/ControlPanel.DNS.Settings.png" />
         <local:MyButton MinWidth="170" Height="35" Padding="10,0" Margin="0,5,20,8" HorizontalAlignment="Left"
         Text="复制 ipconfig /flushdns 命令" EventType="复制文本" EventData="ipconfig /flushdns" />
 

--- a/Minecraft/数据包安装.xaml
+++ b/Minecraft/数据包安装.xaml
@@ -24,28 +24,28 @@
         <Grid>
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
                         Text="1. 在 PCL2 启动器中启动您想要安装数据包的版本，教程内选择 1.17 作为演示。" HorizontalAlignment="Left" />
-            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://z3.ax1x.com/2021/06/24/RMkplt.png" />        
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://resources.cakeskin.tk/file/pcl2-image/datapack/Launch-Game.png" />        
         </Grid>
         <local:MyHint Margin="0,15,0,0" Text="在 Minecraft Java 1.16 版本以下，您需要一个已经创建的世界（存档）才能对这个世界添加数据包" IsWarn="False" />
         <Grid Margin="0,20,0,4">
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
                         Text="2. 点击“单人游戏”，单击选择您想要安装数据包的世界(不是进入世界)，点击下方&quot;编辑&quot; → &quot;打开世界文件夹&quot;" HorizontalAlignment="Left" />
-            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://z3.ax1x.com/2021/06/24/RMFvYd.png" />        
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://resources.cakeskin.tk/file/pcl2-image/datapack/Edit-World.png" />        
         </Grid>
 
         <Grid Margin="0,20,0,4">
-            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://z3.ax1x.com/2021/06/24/RMFxfA.png" />        
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://resources.cakeskin.tk/file/pcl2-image/datapack/Open-Folder.png" />        
         </Grid>
         <Grid Margin="0,20,0,4">
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
                         Text="3. 打开 datapacks 文件夹，并将光标移动到您准备的数据包上右键，点击复制。移动光标至 datapacks 文件夹空白区域，右键，点击粘贴。" HorizontalAlignment="Left" />
-            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://z3.ax1x.com/2021/06/24/RMFjFH.png" />        
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://resources.cakeskin.tk/file/pcl2-image/datapack/View-Folder.png" />        
         </Grid>
 
         <local:MyHint Margin="0,15,0,0" Text="部分数据包压缩包主体内套入了一个文件夹，且包含资源包（材质包），此时您只需要将数据包文件夹移入，并通过以下帮助内的方法安装资源包。&#xa;此外，也可以通过将 zip 格式的资源包重命名为 resources.zip 并放入存档文件夹下以对该存档自动加载特定资源包。" IsWarn="False" />
         <local:MyListItem Margin="0,0,0,0"
 		            EventType="打开帮助" EventData="Minecraft/资源包安装.json" />
-        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="https://z3.ax1x.com/2021/06/24/RMk96P.png"/>
+        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="https://resources.cakeskin.tk/file/pcl2-image/datapack/Unzip-Datapack.png"/>
     </StackPanel>
 </local:MyCard>
 
@@ -65,7 +65,7 @@
                     Text="一般情况下，您只需重新打开存档即可加载数据包。&#xa;您也可以在开启作弊的存档中按 T 输入 /reload 回车，来加载数据包。如果您加载的数据包包含了自定义维度等内容，您必须通过重新进入存档以重新加载数据包。" HorizontalAlignment="Left" />
         <local:MyButton MinWidth="170" Height="35" Padding="10,0" Margin="0,5,20,8" HorizontalAlignment="Left" Grid.Row="1"
                     Text="复制 /reload 文本" EventType="复制文本" EventData="/reload" />
-        <Image Grid.Column="2" Grid.RowSpan="3" HorizontalAlignment="Center" Source="https://z3.ax1x.com/2021/06/24/RM1SUI.png" />
+        <Image Grid.Column="2" Grid.RowSpan="3" HorizontalAlignment="Center" Source="https://resources.cakeskin.tk/file/pcl2-image/datapack/InGame-Effect.png" />
     </Grid>
 </local:MyCard>
 
@@ -76,27 +76,27 @@
         <Grid Margin="0,20,0,4">
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
                         Text="1. 参考上方内容启动您想要安装数据包的版本，点击“单人游戏”。" HorizontalAlignment="Left" />
-            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://z3.ax1x.com/2021/06/24/RMsRBR.png" />        
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://resources.cakeskin.tk/file/pcl2-image/datapack/World-List.png" />        
         </Grid>
         <local:MyHint Margin="0,15,0,0" Text="如果你还没有创建任何世界则无需点击“创建新的世界”按钮，则直接点击右中“数据包”。" IsWarn="False" />
         <Grid Margin="0,20,0,4">
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
                         Text="2. 点击下方“创建新的世界”，点击右中“数据包”" HorizontalAlignment="Left" />
-            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://z3.ax1x.com/2021/06/24/RMyBqA.png" />        
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://resources.cakeskin.tk/file/pcl2-image/datapack/Create-World-Datapack.png" />        
         </Grid>
         <Grid Margin="0,20,0,4">
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
                         Text="3. 打开资源管理器，定位至您准备的数据包，将其拖入 Minecraft 窗口，然后点击“是”" HorizontalAlignment="Left" />
-            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://z3.ax1x.com/2021/06/24/RMgsaR.png" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://resources.cakeskin.tk/file/pcl2-image/datapack/Drag-and-drop-Datapack.png" />
         </Grid>
         <Grid Margin="0,20,0,4">
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
                         Text="4. 此时，您应该能看到左侧 “可用” 列表中有您下载的数据包，将指针移动至图标将出现一个箭头，点击箭头，此时您应该可以看到此数据包移动到了右侧 “已选” 列表，点击 “完成” 应用数据包。" HorizontalAlignment="Left" />
-            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://z3.ax1x.com/2021/06/24/RMfDl6.png" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://resources.cakeskin.tk/file/pcl2-image/datapack/Datapack-List.png" />
         </Grid>
         <local:MyHint Margin="0,15,0,0" Text="如果点击箭头后出现“这个压缩包是为更旧的 Minecraft 版本所打造的,在此版本可能不会正常工作。”等提示，一般点击“是”，可以向他人或该数据包作者请求帮助" IsWarn="False" />
         <Grid Margin="0,20,0,4">
-            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://z3.ax1x.com/2021/06/24/RMgrZ9.png" />        
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://resources.cakeskin.tk/file/pcl2-image/datapack/Confirm-Install.png" />        
         </Grid>
         <TextBlock TextWrapping="Wrap" Margin="0,15,0,4"
                    Text="5. 设置一些你想设置的，如世界名称、游戏模式等，点击下方“创建新的世界”进入游戏。"/>

--- a/Minecraft/整合包安装.xaml
+++ b/Minecraft/整合包安装.xaml
@@ -26,9 +26,9 @@
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
                         Text="对于结尾为 .zip / .rar 的压缩文件整合包，您需打开 PCL 2 启动器，点击“导入整合包”按钮，选择您需要安装的整合包，此处以 “Example.zip” 为范例。" HorizontalAlignment="Left" />
             <StackPanel Margin="250,0,0,0">
-                <Image Source="http://image-pcl2help.test.upcdn.net/modpack/pcl2-modpack-mcbbs-choose-version.png" />
-                <Image Source="http://image-pcl2help.test.upcdn.net/modpack/pcl2-install-modpack-mcbbs.png" />
-                <Image Source="http://image-pcl2help.test.upcdn.net/modpack/pcl2-explorer-choose-modpack.png" />
+                <Image Source="https://resources.cakeskin.tk/file/pcl2-image/modpack/pcl2-modpack-mcbbs-choose-version.png" />
+                <Image Source="https://resources.cakeskin.tk/file/pcl2-image/modpack/pcl2-install-modpack-mcbbs.png" />
+                <Image Source="https://resources.cakeskin.tk/file/pcl2-image/modpack/pcl2-explorer-choose-modpack.png" />
             </StackPanel>
         </Grid>
 
@@ -36,9 +36,9 @@
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
                         Text="此时 PCL2 会弹出“输入版本名”的窗口，您可自由输入。点击“确定”后，PCL2 自动开始安装。安装完毕后，您即可在版本列表选择该游戏。" HorizontalAlignment="Left" />
             <StackPanel Margin="250,0,0,0">
-                <Image Source="http://image-pcl2help.test.upcdn.net/modpack/pcl2-mcbbs-input-version-name.png" />
-                <Image Source="http://image-pcl2help.test.upcdn.net/modpack/pcl2-downloading-mmc-modpack.png" />
-                <Image Source="http://image-pcl2help.test.upcdn.net/modpack/pcl2-mcbbs-launch-game.png" />
+                <Image Source="https://resources.cakeskin.tk/file/pcl2-image/modpack/pcl2-mcbbs-input-version-name.png" />
+                <Image Source="https://resources.cakeskin.tk/file/pcl2-image/modpack/pcl2-downloading-mmc-modpack.png" />
+                <Image Source="https://resources.cakeskin.tk/file/pcl2-image/modpack/pcl2-mcbbs-launch-game.png" />
             </StackPanel>
         </Grid>
     </StackPanel>
@@ -49,16 +49,16 @@
         <Grid>
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
                         Text="1. 在 PCL2 中找到”下载”按钮，在左侧菜单 CurseForge 小项中找到“整合包”选项。" HorizontalAlignment="Left" />
-            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="http://image-pcl2help.test.upcdn.net/modpack/pcl2-download-modpack.png" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://resources.cakeskin.tk/file/pcl2-image/modpack/pcl2-download-modpack.png" />
         </Grid>
 
         <Grid Margin="0,20,0,4">
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
                         Text="2. 选择一个整合包。本教程使用&quot;RLCraft&quot; 为范例。点击此整合包，点击最上方的版本，PCL2 会自动弹出输入版本名的窗口，您可自由输入，此处以“RLCraft”为范例，点击确定，PCL2 会自动开始下载。" HorizontalAlignment="Left" />
-            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="http://image-pcl2help.test.upcdn.net/modpack/pcl2-choose-modpack.png" />
-            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="http://image-pcl2help.test.upcdn.net/modpack/pcl2-choose-modpack-version.png" />
-            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="http://image-pcl2help.test.upcdn.net/modpack/pcl2-input-version-name.png" />
-            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="http://image-pcl2help.test.upcdn.net/modpack/pcl2-download-start" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://resources.cakeskin.tk/file/pcl2-image/modpack/pcl2-choose-modpack.png" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://resources.cakeskin.tk/file/pcl2-image/modpack/pcl2-choose-modpack-version.png" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://resources.cakeskin.tk/file/pcl2-image/modpack/pcl2-input-version-name.png" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://resources.cakeskin.tk/file/pcl2-image/modpack/pcl2-download-start" />
         </Grid>
 
         <Grid Margin="0,20,0,4">

--- a/Minecraft/设置分配内存大小.xaml
+++ b/Minecraft/设置分配内存大小.xaml
@@ -13,16 +13,16 @@
     <StackPanel Margin="25,40,23,15">   
         <TextBlock Margin="0,4,0,4" LineHeight="20"
                    Text="1. 打开您的 PCL 2 启动器，在主页点击左下方的“版本选择”按钮。" />
-        <Image HorizontalAlignment="Center" Source="https://z3.ax1x.com/2021/04/30/gE4hj0.png" />             
+        <Image HorizontalAlignment="Center" Source="https://resources.cakeskin.tk/file/pcl2-image/set-game-memory/Choose-Version.png" />             
         <TextBlock Margin="0,4,0,4" LineHeight="20"
                    Text="2. 在版本选择列表中，右键点击需要修改内存的游戏版本。" />
-        <Image HorizontalAlignment="Center" Source="https://z3.ax1x.com/2021/04/30/gE4oHU.png" />
+        <Image HorizontalAlignment="Center" Source="https://resources.cakeskin.tk/file/pcl2-image/set-game-memory/Version-Lists.png" />
         <TextBlock Margin="0,4,0,4" LineHeight="20"
                    Text="3. 在该版本的设置中，点击左侧的“设置”选项卡。" />
-        <Image HorizontalAlignment="Center" Source="https://z3.ax1x.com/2021/04/30/gE4IBT.png" />        
+        <Image HorizontalAlignment="Center" Source="https://resources.cakeskin.tk/file/pcl2-image/set-game-memory/Version-Settings.png" />        
         <TextBlock Margin="0,4,0,4" LineHeight="20"
                    Text="4. 滑动至下方，找到“游戏内存”选项卡，选择“自定义”，然后滑动圆点即可手动调整。&#xa;此时，该版本的启动内存已为固定值，不再自动变更。" />
-        <Image HorizontalAlignment="Center" Source="https://z3.ax1x.com/2021/04/30/gE45uV.png" />    
+        <Image HorizontalAlignment="Center" Source="https://resources.cakeskin.tk/file/pcl2-image/set-game-memory/Set-Memory.png" />    
     </StackPanel>
 </local:MyCard>
 
@@ -33,10 +33,10 @@
 		<local:MyHint Margin="0,-5,0,15" Text="请注意，修改 PCL 2 的全局配置将影响所有依赖 PCL 2 启动的游戏版本。"/>
         <TextBlock Margin="0,0,0,4" LineHeight="20"
                    Text="1. 打开您的 PCL 2 启动器，在主页点击上方的“设置”选单。" />
-        <Image HorizontalAlignment="Center" Source="https://cdn.jsdelivr.net/gh/Dongyifengs/PCLCDN@main/Setting.png" />             
+        <Image HorizontalAlignment="Center" Source="https://resources.cakeskin.tk/file/pcl2-image/set-game-memory/Setting.png" />             
         <TextBlock Margin="0,4,0,4" LineHeight="20"
                    Text="2. 点击左侧的“游戏”选项卡，向下翻找，找到“游戏内存”选项卡。" />
-        <Image HorizontalAlignment="Center" Source="https://cdn.jsdelivr.net/gh/Dongyifengs/PCLCDN@main/Storage.png" />
+        <Image HorizontalAlignment="Center" Source="https://resources.cakeskin.tk/file/pcl2-image/set-game-memory/Storage.png" />
         <TextBlock Margin="0,4,0,4" LineHeight="20"
                    Text="3. 选择“自定义”，此时拖动圆点即可手动调整全局内存。" />
     </StackPanel>

--- a/Minecraft/资源包安装.xaml
+++ b/Minecraft/资源包安装.xaml
@@ -22,30 +22,30 @@
         <Grid>
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
                         Text="1. 在 PCL2 启动器中找到您想要安装资源包的版本，如教程内选择 1.16.5 作为演示。" HorizontalAlignment="Left" />
-            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="http://image-pcl2help.test.upcdn.net/main/pcl2-find-version-add-mosaic.png" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://resources.cakeskin.tk/file/pcl2-image/main/pcl2-find-version-add-mosaic.png" />
         </Grid>
 
         <Grid Margin="0,20,0,4">
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
                         Text="2. 点击最右侧的齿轮打开 “版本设置”，点击下方 “打开版本文件夹” 按钮。" HorizontalAlignment="Left" />
-            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="http://image-pcl2help.test.upcdn.net/main/pcl2-open-folder-regular.png" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://resources.cakeskin.tk/file/pcl2-image/main/pcl2-open-folder-regular.png" />
         </Grid>
 
         <Grid Margin="0,20,0,4">
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
                         Text="3. 此时，您应该能在弹出的资源管理器界面中看见 “resourcepacks” 文件夹。" HorizontalAlignment="Left" />
-            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="http://image-pcl2help.test.upcdn.net/main/explorer-resource-pack-folder-find.png" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://resources.cakeskin.tk/file/pcl2-image/main/explorer-resource-pack-folder-find.png" />
         </Grid>
 
         <Grid Margin="0,20,0,4">
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
                         Text="4. 打开 “resourcepacks” 文件夹，并将您的资源包拖入 ”resourcepacks“ 文件夹。" HorizontalAlignment="Left" />
-            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="http://image-pcl2help.test.upcdn.net/main/explorer-prepared-put-into-resourcepack-folder.png" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://resources.cakeskin.tk/file/pcl2-image/main/explorer-prepared-put-into-resourcepack-folder.png" />
         </Grid>
 
         <local:MyHint Margin="0,15,0,0" Text="注意：部分资源包压缩包主体内套入了一个文件夹，此时你可以直接将此文件夹解压至 “resourcepacks” 文件夹使用。（如下图）" IsWarn="False" />
-        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="http://image-pcl2help.test.upcdn.net/main/bandizip-zip-folder.png"/>
-        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="http://image-pcl2help.test.upcdn.net/main/explorer-resourcepack-folder-resourcepack.png"/>
+        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="https://resources.cakeskin.tk/file/pcl2-image/main/bandizip-zip-folder.png"/>
+        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="https://resources.cakeskin.tk/file/pcl2-image/main/explorer-resourcepack-folder-resourcepack.png"/>
     </StackPanel>
 </local:MyCard>
 
@@ -55,8 +55,8 @@
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
                         Text="1. 启动您的游戏，打开 “选项 > 资源包”。" HorizontalAlignment="Left" />
                 <StackPanel Margin="250,0,0,0">
-                    <Image HorizontalAlignment="Center" Source="http://image-pcl2help.test.upcdn.net/main/minecraft-settings.png" />
-                    <Image HorizontalAlignment="Center" Margin="0,15,0,0" Source="http://image-pcl2help.test.upcdn.net/main/minecraft-settings-resourcepack.png" />
+                    <Image HorizontalAlignment="Center" Source="https://resources.cakeskin.tk/file/pcl2-image/main/minecraft-settings.png" />
+                    <Image HorizontalAlignment="Center" Margin="0,15,0,0" Source="https://resources.cakeskin.tk/file/pcl2-image/main/minecraft-settings-resourcepack.png" />
                 </StackPanel>
         </Grid>
 
@@ -64,8 +64,8 @@
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
                         Text="2. 此时，您应该能看到左侧 “可用” 列表中有您下载的资源包名称，将指针移动至图标上方，将出现一个箭头，点击箭头，此时您应该可以看到此资源包移动到了右侧 “已选” 列表，点击 “完成” 应用资源包。" HorizontalAlignment="Left" />
             <StackPanel Margin="250,0,0,0">
-                <Image HorizontalAlignment="Center" Source="http://image-pcl2help.test.upcdn.net/main/minecraft-resourcepack-choose.png" />
-                <Image HorizontalAlignment="Center" Margin="0,15,0,0" Source="http://image-pcl2help.test.upcdn.net/main/minecraft-resourcepack-left.png" />
+                <Image HorizontalAlignment="Center" Source="https://resources.cakeskin.tk/file/pcl2-image/main/minecraft-resourcepack-choose.png" />
+                <Image HorizontalAlignment="Center" Margin="0,15,0,0" Source="https://resources.cakeskin.tk/file/pcl2-image/main/minecraft-resourcepack-left.png" />
             </StackPanel>
         </Grid>
 
@@ -82,15 +82,15 @@
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
                         Text="1. 启动您的游戏，打开选项——资源包。" HorizontalAlignment="Left" />
                 <StackPanel Margin="250,0,0,0">
-                  <Image HorizontalAlignment="Center" Source="http://image-pcl2help.test.upcdn.net/main/minecraft-settings.png" />
-                  <Image HorizontalAlignment="Center" Margin="0,15,0,0" Source="http://image-pcl2help.test.upcdn.net/main/minecraft-settings-resourcepack.png" />
+                  <Image HorizontalAlignment="Center" Source="https://resources.cakeskin.tk/file/pcl2-image/main/minecraft-settings.png" />
+                  <Image HorizontalAlignment="Center" Margin="0,15,0,0" Source="https://resources.cakeskin.tk/file/pcl2-image/main/minecraft-settings-resourcepack.png" />
                 </StackPanel>
         </Grid>
 
         <Grid Margin="0,20,0,4">
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
                         Text="2. 找到您下载的资源包，将其文件直接拖至 Minecraft 窗口内。此时会弹出一个提示询问安装，点击 “是”。" HorizontalAlignment="Left" />
-            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="http://image-pcl2help.test.upcdn.net/main/minecraft-1.16+-resourcepack-true.png" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://resources.cakeskin.tk/file/pcl2-image/main/minecraft-1.16+-resourcepack-true.png" />
         </Grid>
 
         <TextBlock TextWrapping="Wrap" Margin="0,15,0,4"

--- a/帮助/提交帮助 - VSCode.xaml
+++ b/帮助/提交帮助 - VSCode.xaml
@@ -40,10 +40,10 @@
                     Text="最后，点击左边栏 → 源代码管理 → 打开文件夹，选择 Help 文件夹即可。"/>
         <TextBlock Margin="0,0,0,4" LineHeight="17"
         Text="在获取帮助库后，你就可以按照正常自定义帮助的方式对帮助库进行修改了。修改完成后，点击右侧的第三个按钮&quot;源代码管理&quot;或按下键盘上的 Ctrl 键 + Shit 键 + G 键，在上方输入你的修改内容，点击&quot;更改&quot;旁边的 + 号，再点击&quot;源代码管理&quot;旁边的 + 号，将你的更新暂存，再点击下方的&quot;master&quot;旁边的按钮，你的更新就被推送到你的 Fork 仓库了。"/>
-        <Image HorizontalAlignment="Center" Source="http://image-pcl2help.test.upcdn.net/vscode-push-changes/VSCode.Pull.Changes.png" />
+        <Image HorizontalAlignment="Center" Source="https://resources.cakeskin.tk/file/pcl2-image/vscode-push-changes/VSCode.Pull.Changes.png" />
         <TextBlock Margin="0,0,0,4" LineHeight="17"
         Text="在 Pull Request 前，你需要同步原仓库内的内容以保证你的仓库保持最新。打开你的 Fork 仓库主页，找到&quot;Fetch upstream (从上游获取)&quot;按钮并点击，再点击&quot;Fetch and merge (获取并合并)&quot;，你的仓库就同步了原仓库。经过了这些步骤之后，你就可以提交你的 Pull Request 了。"/>
-        <Image HorizontalAlignment="Center" Source="http://image-pcl2help.test.upcdn.net/vscode-push-changes/Github.Fetch.upstream.png" />
+        <Image HorizontalAlignment="Center" Source="https://resources.cakeskin.tk/file/pcl2-image/vscode-push-changes/Github.Fetch.upstream.png" />
     </StackPanel>
 </local:MyCard>
 


### PR DESCRIPTION
根据 z0z0r4 的意见，因为又拍云的 CDN 与对象存储容易被打，而我目前使用的是又拍云联盟的代金券，所以对 DDoS 与 CC 攻击没有任何抵抗能力，因此进行此操作。

以及，将其他第三方图床的图片进行留档，防止图片丢失。