### PR TITLE
制作整合包时，账号Token随着LatestLaunch.bat传播的风险

### DIFF
--- a/指南/整合包制作 - Public.xaml
+++ b/指南/整合包制作 - Public.xaml
@@ -17,7 +17,7 @@
 <local:MyCard Title="删除自己的账号信息" CanSwap="True" IsSwaped="True">
     <StackPanel Margin="25,40,23,11">
 	    <TextBlock Margin="0,0,0,4" LineHeight="17"
-                   Text="PCL2 将你的账号、密码等重要信息加密存储在注册表中，而不是文件中。&#xa;因此，你无需刻意删除你的账号信息，它们不会随着你的整合包被发放给其他人。" />
+                   Text="PCL2 将你的账号、密码等重要信息加密存储在注册表中，而不是文件中。&#xa;你仅需删除PCL目录下的LatestLaunch.bat，因为该文件中含有您的账号Token。" />
     </StackPanel>
 </local:MyCard>
 

--- a/指南/整合包制作 - Public.xaml
+++ b/指南/整合包制作 - Public.xaml
@@ -17,7 +17,7 @@
 <local:MyCard Title="删除自己的账号信息" CanSwap="True" IsSwaped="True">
     <StackPanel Margin="25,40,23,11">
 	    <TextBlock Margin="0,0,0,4" LineHeight="17"
-                   Text="PCL2 将你的账号、密码等重要信息加密存储在注册表中，而不是文件中。&#xa;你仅需删除PCL目录下的LatestLaunch.bat，因为该文件中含有您的账号Token。" />
+                   Text="PCL2 将你的账号、密码等重要信息加密存储在注册表中，而不是文件中。&#xa;你仅需删除PCL目录下的LatestLaunch.bat，因为该文件中含有你的账号Token。" />
     </StackPanel>
 </local:MyCard>
 

--- a/指南/整合包制作 - Snapshot.xaml
+++ b/指南/整合包制作 - Snapshot.xaml
@@ -19,7 +19,7 @@
 <local:MyCard Title="删除自己的账号信息" CanSwap="True" IsSwaped="True">
     <StackPanel Margin="25,40,23,11">
 	    <TextBlock Margin="0,0,0,4" LineHeight="17"
-                   Text="PCL2 将你的账号、密码等重要信息加密存储在注册表中，而不是文件中。&#xa;你仅需删除PCL目录下的LatestLaunch.bat，因为该文件中含有您的账号Token。" />
+                   Text="PCL2 将你的账号、密码等重要信息加密存储在注册表中，而不是文件中。&#xa;你仅需删除PCL目录下的LatestLaunch.bat，因为该文件中含有你的账号Token。" />
     </StackPanel>
 </local:MyCard>
 

--- a/指南/整合包制作 - Snapshot.xaml
+++ b/指南/整合包制作 - Snapshot.xaml
@@ -19,7 +19,7 @@
 <local:MyCard Title="删除自己的账号信息" CanSwap="True" IsSwaped="True">
     <StackPanel Margin="25,40,23,11">
 	    <TextBlock Margin="0,0,0,4" LineHeight="17"
-                   Text="PCL2 将你的账号、密码等重要信息加密存储在注册表中，而不是文件中。&#xa;因此，你无需刻意删除你的账号信息，它们不会随着你的整合包被发放给其他人。" />
+                   Text="PCL2 将你的账号、密码等重要信息加密存储在注册表中，而不是文件中。&#xa;你仅需删除PCL目录下的LatestLaunch.bat，因为该文件中含有您的账号Token。" />
     </StackPanel>
 </local:MyCard>
 


### PR DESCRIPTION
由于整合包用户可直接通过LatestLaunch.bat以作者的账号登录，因此，必须让作者删除LatestLaunch.bat，避免安全风险。