### PR TITLE
更新登录方面的帮助文档

### DIFF
--- a/启动器/LittleSkin 外置登录使用教程.xaml
+++ b/启动器/LittleSkin 外置登录使用教程.xaml
@@ -13,15 +13,11 @@
 
 <local:MyCard Title="教程">
     <StackPanel Margin="25,40,23,15">
-        <local:MyHint Margin="0,0,0,0" Text="本教程部分内容涉及到对 PCL2 启动器的设置，建议对照网页版教程操作。" IsWarn="False" />
-        <!-- 这个网页有点问题，建议修改一下 -->
-        <local:MyButton Margin="0,10,0,0" MinWidth="140" Padding="13,0" HorizontalAlignment="Left" Height="35" Text="打开网页版教程" EventType="打开网页" EventData="https://note.youdao.com/s/fHxFNnq" />
-
         <local:MyHint Margin="0,10,0,0" Text="以下填写的所有邮箱地址应全部为英文小写字母，否则将会出现 UUID 为 null 的情况导致无法进入服务器！" IsWarn="True" />
+        
         <TextBlock Margin="0,10,0,0" Text="1. 前往 LittleSkin 注册一个账号。" />
         <local:MyHint Margin="0,10,0,0" Text="在注册 LittleSkin 账号时不要使用第三方登录，可能会导致账号无法设置密码，从而无法继续操作！" IsWarn="False" />
         <local:MyButton Margin="0,10,0,0" MinWidth="140" Padding="13,0" HorizontalAlignment="Left" Height="35" Text="打开 LittleSkin 注册界面" EventType="打开网页" EventData="https://littleskin.cn/auth/register" />
-
         <Image Margin="0,10,0,0" Height="360" HorizontalAlignment="Left" Source ="https://cdn.img.z0z0r4.top/2022/07/10/1/img1.png" />
 
         <TextBlock Margin="0,50,0,0" Text="2. 进入“仪表盘”，点击左侧“角色管理”，再点击“添加新角色”。" />

--- a/启动器/LittleSkin 外置登录使用教程.xaml
+++ b/启动器/LittleSkin 外置登录使用教程.xaml
@@ -1,46 +1,55 @@
+<!-- 2023/02/20 修改掉的图片 https://wwou.lanzoub.com/iA9gY0o28i9c -->
+<!-- 2023/02/20 添加的图片 https://wwou.lanzoub.com/iS4Xr0o4vr4b 目前没有加箭头，可以加一下 -->
+
 <local:MyCard Title="简介及注意事项">
     <StackPanel Margin="25,40,23,15">
-        <TextBlock Margin="0,0,0,0" LineHeight="17" Text="PCL2 支持外置登录，设置 LittleSkin 的外置登录可以用于非正版联机，或者使用来自 LittleSkin 的皮肤" />
-        <local:MyHint Margin="0,10,0,0" Text="如果您想用于联机，那么请再次注意，联机仅对加入者有要求(加入者必须是正版登录或外置登录)，对房主无任何要求&#x000A;如果您想在多人游戏中展示您的皮肤，请保证所有参与联机的成员均使用 LittleSkin 外置登录，或搭配 CustomSkinLoader 模组并添加 ExtraList 文件（仅当皮肤显示不正常时）以达到相同的效果" IsWarn="False" />
-        <local:MyHint Margin="0,10,0,0" Text="另请注意：LittleSkin 外置登录本质上仍然是离线登录，不能用于进入正版服务器" IsWarn="True" />
+        <TextBlock Margin="0,0,0,0" LineHeight="17" Text="PCL2 支持外置登录，设置 LittleSkin 的外置登录可以用于游玩非正版服务器，或者使用来自 LittleSkin 的皮肤。" />
+        <TextBlock Margin="0,10,0,0" Text="如果您想用于联机，那么联机加入者必须是正版或外置登录，对房主则无要求。" />
+        <TextBlock Margin="0,10,0,0" Text="如果您想在多人游戏中展示您的皮肤，请保证所有参与联机的成员均使用 LittleSkin 外置登录。皮肤显示不正常时，也可以搭配 CustomSkinLoader 模组并添加 ExtraList 文件以达到相同的效果。" />
+        <local:MyHint Margin="0,10,0,0" Text="请注意：LittleSkin 外置登录不能用于进入正版服务器。" IsWarn="False" />
         <local:MyButton Margin="0,10,0,0" MinWidth="280" Padding="13,0" HorizontalAlignment="Left" Height="35" Text="获取配置文件（须登录 LittleSkin）" EventType="打开网页" EventData="https://littleskin.cn/user/config" />
     </StackPanel>
 </local:MyCard>
 
-
 <local:MyCard Title="教程">
     <StackPanel Margin="25,40,23,15">
-        <local:MyHint Margin="0,0,0,0" Text="本教程部分内容涉及到对 PCL2 启动器的设置，建议对照网页版教程操作" IsWarn="False" />
+        <local:MyHint Margin="0,0,0,0" Text="本教程部分内容涉及到对 PCL2 启动器的设置，建议对照网页版教程操作。" IsWarn="False" />
+        <!-- 这个网页有点问题，建议修改一下 -->
         <local:MyButton Margin="0,10,0,0" MinWidth="140" Padding="13,0" HorizontalAlignment="Left" Height="35" Text="打开网页版教程" EventType="打开网页" EventData="https://note.youdao.com/s/fHxFNnq" />
 
-        <local:MyHint Margin="0,10,0,0" Text="以下填写的所有邮箱地址应全部为英文小写字母，否则将会出现 UUID 为 null 的情况导致无法进入服务器!" IsWarn="True" />
-        <TextBlock Margin="0,10,0,0" Text="1. 前往 LittleSkin 注册一个账号" />
-        <local:MyHint Margin="0,10,0,0" Text="请在注册 LittleSkin 账号时不要使用第三方登录，这可能会导致您的账号无法设置密码从而无法继续操作" IsWarn="False" />
+        <local:MyHint Margin="0,10,0,0" Text="以下填写的所有邮箱地址应全部为英文小写字母，否则将会出现 UUID 为 null 的情况导致无法进入服务器！" IsWarn="True" />
+        <TextBlock Margin="0,10,0,0" Text="1. 前往 LittleSkin 注册一个账号。" />
+        <local:MyHint Margin="0,10,0,0" Text="在注册 LittleSkin 账号时不要使用第三方登录，可能会导致账号无法设置密码，从而无法继续操作！" IsWarn="False" />
         <local:MyButton Margin="0,10,0,0" MinWidth="140" Padding="13,0" HorizontalAlignment="Left" Height="35" Text="打开 LittleSkin 注册界面" EventType="打开网页" EventData="https://littleskin.cn/auth/register" />
 
         <Image Margin="0,10,0,0" Height="360" HorizontalAlignment="Left" Source ="https://cdn.img.z0z0r4.top/2022/07/10/1/img1.png" />
 
-        <TextBlock Margin="0,50,0,0" Text="2. 注册完以后，进入 仪表盘 点击左侧“角色管理”，再点击“添加新角色”" />
+        <TextBlock Margin="0,50,0,0" Text="2. 进入“仪表盘”，点击左侧“角色管理”，再点击“添加新角色”。" />
         <local:MyButton Margin="0,10,0,0" MinWidth="140" Padding="13,0" HorizontalAlignment="Left" Height="35" Text="打开 LittleSkin 用户中心" EventType="打开网页" EventData="https://littleskin.cn/user" />
         <Image Margin="0,10,0,0" Height="360" HorizontalAlignment="Left" Source="https://cdn.img.z0z0r4.top/2022/07/10/1/img2.png" />
 
-        <TextBlock Margin="0,50,0,0" Text="3. 在弹出的窗口内输入角色名（这将会成为联机时的ID，也即游戏中的用户名），填写完成后点击“确定”" />
+        <TextBlock Margin="0,50,0,0" Text="3. 在弹出的窗口内输入角色名（这将会成为联机时的 ID，即游戏中的用户名），填写完成后点击“确定”。" />
         <Image Margin="0,20,0,0" Height="360" HorizontalAlignment="Left" Source="https://cdn.img.z0z0r4.top/2022/07/10/1/img3.png" />
 
-        <TextBlock Margin="0,50,0,0" Text="4. 打开 PCL2 启动器，点击左下角的“版本选择”" />
-        <Image Margin="0,20,0,0" Height="360" HorizontalAlignment="Left" Source="https://cdn.img.z0z0r4.top/2022/07/10/1/img4.png" />
+        <TextBlock Margin="0,50,0,0" Text="4. 打开 PCL2，点击左下角的“版本选择”。" />
+        <Image Margin="0,20,0,0" Height="360" HorizontalAlignment="Left" Source="https://cdn.img.z0z0r4.top/2023/02/19/63f20230b5136.png" />
 
-        <TextBlock Margin="0,50,0,0" Text="5. 右键点击将要启动的游戏版本" />
-        <Image Margin="0,20,0,0" Height="360" HorizontalAlignment="Left"  Source ="https://cdn.img.z0z0r4.top/2022/07/10/1/img5.png" />
+        <TextBlock Margin="0,50,0,0" Text="5. 右键点击将要启动的游戏版本。" />
+        <Image Margin="0,20,0,0" Height="360" HorizontalAlignment="Left"  Source="https://cdn.img.z0z0r4.top/2023/02/19/63f20230bedd5.png" />
 
-        <TextBlock Margin="0,50,0,0" Text="6. 点击左侧“设置”选项，并滑动到页面底部，登录方式选择“第三方登录：Authlib-Injector 或 LittleSkin”" />
-        <Image Margin="0,20,0,0" Height="360" HorizontalAlignment="Left" Source ="https://cdn.img.z0z0r4.top/2022/07/10/1/img6.png" />
+        <TextBlock Margin="0,50,0,0" Text="6. 点击左侧“设置”选项。" />
+        <Image Margin="0,20,0,0" Height="360" HorizontalAlignment="Left" Source="https://cdn.img.z0z0r4.top/2023/02/19/63f20230c9e9b.png" />
 
-        <TextBlock Margin="0,50,0,0" Text="7. 点击下方“设置为 LittleSkin”按钮，并点击“确定”" />   
-        <Image Margin="0,20,0,0" Height="360" HorizontalAlignment="Left" Source ="https://cdn.img.z0z0r4.top/2022/11/19/6/1668859331782.png" />
+        <TextBlock Margin="0,50,0,0" Text="7. 滑动到页面底部，在“服务器选项”中把登录方式设为“第三方登录：Authlib Injector 或 LittleSkin”" />   
+        <Image Margin="0,20,0,0" Height="360" HorizontalAlignment="Left" Source="https://cdn.img.z0z0r4.top/2023/02/20/63f36df35222d.png" />
 
-        <TextBlock Margin="0,50,0,0" Text="8. 返回主菜单并输入你的 LiitleSkin 账号，点击“启动游戏”即可" />   
-        <Image Margin="0,20,0,0" Height="360" HorizontalAlignment="Left" Source ="https://cdn.img.z0z0r4.top/2022/11/19/6/littleskin-login.png" />
+        <TextBlock Margin="0,50,0,0" Text="8. 点击下方“设置为 LittleSkin”按钮，并点击“确定”。" />   
+        <Image Margin="0,20,0,0" Height="360" HorizontalAlignment="Left" Source="https://cdn.img.z0z0r4.top/2023/02/20/63f36e0268931.png" />
+
+        <TextBlock Margin="0,50,0,0" Text="9. 返回主菜单并输入你的 LittleSkin 账号，点击“启动游戏”即可。" />   
+        <Image Margin="0,20,0,0" Height="360" HorizontalAlignment="Left" Source="https://cdn.img.z0z0r4.top/2023/02/20/63f36e13ba79e.png" />
+        
+        <TextBlock Margin="0,50,0,0" Text="在启动游戏后，PCL2 能够记忆你的账号，并且可以进行更换角色、更改皮肤、退出登录等操作。" />
     </StackPanel>
 </local:MyCard>
 

--- a/启动器/指定登录方式.xaml
+++ b/启动器/指定登录方式.xaml
@@ -1,30 +1,32 @@
-<local:MyHint Margin="0,0,0,15" Text="该帮助页面还需要进一步完善。如果你感兴趣也可以来帮帮忙！" IsWarn="False" />
+<local:MyHint Margin="0,0,0,15" Text="该帮助页面还需要根据规范重新整理格式，优化排版与文案。如果你感兴趣也可以来帮帮忙！" IsWarn="False" />
+
 <!-- 需要根据规范重新整理格式、标点、空格等。部分语句不太通顺，需要再改改。 -->
-<!-- 图片备份https://yshs.lanzoui.com/iIquToi85kf -->
+<!-- 图片备份 https://yshs.lanzoui.com/iIquToi85kf -->
+<!-- 2023/02/20 添加的图片 https://wwou.lanzoub.com/ijvOW0o1xrne 目前没有加箭头，可以加一下 -->
 
 <local:MyCard Title="简介">
     <StackPanel Margin="25,40,23,15">
-        <TextBlock Margin="0,0,0,0" LineHeight="17" Text="PCL2 支持多种登录方式，可以单独为某一版本指定登录方式。支持 离线登录、正版登录、统一通行证 和 Authlib-Injector 登录，此界面将提供简单的教程。" />
+        <TextBlock Margin="0,0,0,0" LineHeight="17" Text="PCL2 支持多种登录方式，例如正版登录、离线登录、统一通行证和 Authlib-Injector 登录，也可以单独为某一版本指定登录方式。此界面将提供简单的教程。" />
     </StackPanel>
 </local:MyCard>
 
 <local:MyCard Title="教程">
     <StackPanel Margin="25,40,23,15">
-        <TextBlock Margin="0,10,0,0" Text="1. 点击下方“版本选择”。" />
-        <Image Height="360" Margin="0,20,0,0" HorizontalAlignment="Left" Source="https://cdn.img.z0z0r4.top/2022/07/10/1/imgdl1.png" />
+        <TextBlock Margin="0,10,0,0" Text="1. 点击启动页面下方的“版本选择”。" />
+        <Image Height="360" Margin="0,20,0,0" HorizontalAlignment="Left" Source="https://cdn.img.z0z0r4.top/2023/02/19/63f20230b5136.png" />
 
         <TextBlock Margin="0,50,0,0" Text="2. 右键点击需要修改的游戏版本。" />
-        <Image Height="360" Margin="0,20,0,0" HorizontalAlignment="Left" Source="https://cdn.img.z0z0r4.top/2022/07/10/1/imgdl2.png" />
+        <Image Height="360" Margin="0,20,0,0" HorizontalAlignment="Left" Source="https://cdn.img.z0z0r4.top/2023/02/19/63f20230bedd5.png" />
 
         <TextBlock Margin="0,50,0,0" Text="3. 点击左侧“设置”按钮。" />
-        <Image Height="360" Margin="0,20,0,0" HorizontalAlignment="Left" Source="https://cdn.img.z0z0r4.top/2022/07/10/1/imgdl3.png" />
+        <Image Height="360" Margin="0,20,0,0" HorizontalAlignment="Left" Source="https://cdn.img.z0z0r4.top/2023/02/19/63f20230c9e9b.png" />
         
-        <TextBlock Margin="0,50,0,0" Text="4. 滑动至下方“服务器选项”，选择登录方式即可切换。" />
-        <Image Height="360" Margin="0,20,0,0" HorizontalAlignment="Left" Source="https://cdn.img.z0z0r4.top/2022/07/10/1/imgdl4.png" />
+        <TextBlock Margin="0,50,0,0" Text="4. 滑动至下方，在“服务器”中选择登录方式即可切换。" />
+        <Image Height="360" Margin="0,20,0,0" HorizontalAlignment="Left" Source="https://cdn.img.z0z0r4.top/2023/02/19/63f2023198b0c.png" />
     </StackPanel>
 </local:MyCard>
 
-<local:MyCard Title="具体应用">
+<local:MyCard Title="设置 LittleSkin 登录">
     <StackPanel Margin="25,40,23,15">
         <local:MyListItem Margin="0,0,0,0" EventType="打开帮助" EventData="启动器/LittleSkin 外置登录使用教程.json" />
     </StackPanel>

--- a/启动器/指定登录方式.xaml
+++ b/启动器/指定登录方式.xaml
@@ -1,25 +1,23 @@
-<local:MyHint Margin="0,0,0,15" Text="该帮助页面还需要根据规范重新整理格式，优化排版与文案。如果你感兴趣也可以来帮帮忙！" IsWarn="False" />
-
 <!-- 需要根据规范重新整理格式、标点、空格等。部分语句不太通顺，需要再改改。 -->
 <!-- 图片备份 https://yshs.lanzoui.com/iIquToi85kf -->
 <!-- 2023/02/20 添加的图片 https://wwou.lanzoub.com/ijvOW0o1xrne 目前没有加箭头，可以加一下 -->
-
+<!--
 <local:MyCard Title="简介">
     <StackPanel Margin="25,40,23,15">
         <TextBlock Margin="0,0,0,0" LineHeight="17" Text="PCL2 支持多种登录方式，例如正版登录、离线登录、统一通行证和 Authlib-Injector 登录，也可以单独为某一版本指定登录方式。此界面将提供简单的教程。" />
     </StackPanel>
 </local:MyCard>
-
+-->
 <local:MyCard Title="教程">
     <StackPanel Margin="25,40,23,15">
         <TextBlock Margin="0,10,0,0" Text="1. 点击启动页面下方的“版本选择”。" />
         <Image Height="360" Margin="0,20,0,0" HorizontalAlignment="Left" Source="https://cdn.img.z0z0r4.top/2023/02/19/63f20230b5136.png" />
 
         <TextBlock Margin="0,50,0,0" Text="2. 右键点击需要修改的游戏版本。" />
-        <Image Height="360" Margin="0,20,0,0" HorizontalAlignment="Left" Source="https://cdn.img.z0z0r4.top/2023/02/19/63f20230bedd5.png" />
+        <Image Height="360" Margin="0,20,0,0" HorizontalAlignment="Left" Source="https://cdn.img.z0z0r4.top/2023/02/19/63f20230c9e9b.png" />
 
         <TextBlock Margin="0,50,0,0" Text="3. 点击左侧“设置”按钮。" />
-        <Image Height="360" Margin="0,20,0,0" HorizontalAlignment="Left" Source="https://cdn.img.z0z0r4.top/2023/02/19/63f20230c9e9b.png" />
+        <Image Height="360" Margin="0,20,0,0" HorizontalAlignment="Left" Source="https://cdn.img.z0z0r4.top/2023/02/19/63f20230bedd5.png" />
         
         <TextBlock Margin="0,50,0,0" Text="4. 滑动至下方，在“服务器”中选择登录方式即可切换。" />
         <Image Height="360" Margin="0,20,0,0" HorizontalAlignment="Left" Source="https://cdn.img.z0z0r4.top/2023/02/19/63f2023198b0c.png" />


### PR DESCRIPTION
~~又是被 Git 折磨的一天~~ 改的东西有点多，下面大致说一下……

以下行号均为修改后的行号。
- 启动器/指定登录方式.xaml
  - 行 1：更新“还需要进一步完善”的提示为标准格式；
  - 行 15-25：更新了图片，主要为了迎合 帮助库编写规范——图片规范 第 3 条，使用龙猫蓝主题颜色，且不使用背景图片；并且截图更新为最新版本的 PCL2 正式版；
  - 行 29：改了一下标题，如果觉得原来那个比较好的话也可以改回去……
- 启动器/LittleSkin 外置登录使用教程.xaml
  - 行 6-9：改掉了一些 `MyHint`；
  - 行 34-50：更新了图片，主要为了迎合 帮助库编写规范——图片规范 第 3 条，使用龙猫蓝主题颜色，且不使用背景图片；并且截图更新为最新版本的 PCL2 正式版；统一了 PCL2 的窗口大小、背景图片等。

并且在 LittleSkin 帮助中，原来的第 42 行把 LittleSkin 拼成了 LiitleSkin……
如果觉得有些修改没必要的话可以改回去.jpg