### PR TITLE
更新 Git 按钮文字

### DIFF
--- a/帮助/提交帮助 - Git.xaml
+++ b/帮助/提交帮助 - Git.xaml
@@ -20,9 +20,9 @@
                     Text="在开始获取 PCL2 帮助库之前不可缺少的是安装 Git 工具，你可以直接通过下面的按钮下载，或访问网页下载。"/>
 		<StackPanel Height="35" Margin="0,4,0,10" Orientation="Horizontal">
 			<local:MyButton MinWidth="140" Padding="13,0" Margin="0,0,20,0" HorizontalAlignment="Left" ColorType="Highlight"
-                        Text="点击下载 Git(32位)" EventType="下载文件" EventData="https://registry.npmmirror.com/-/binary/git-for-windows/v2.39.2.windows.1/Git-2.39.2-32-bit.exe" />
-			<local:MyButton MinWidth="140" Padding="13,0" Margin="0,0,20,0" HorizontalAlignment="Left"
-                        Text="点击下载 Git(64位)" EventType="下载文件" EventData="https://registry.npmmirror.com/-/binary/git-for-windows/v2.39.2.windows.1/Git-2.39.2-64-bit.exe" />
+                        Text="下载 Git (32 位)" EventType="下载文件" EventData="https://registry.npmmirror.com/-/binary/git-for-windows/v2.39.2.windows.1/Git-2.39.2-32-bit.exe" />
+			<local:MyButton MinWidth="140" Padding="13,0" Margin="0,0,20,0" HorizontalAlignment="Left" ColorType="Highlight"
+                        Text="下载 Git (64 位)" EventType="下载文件" EventData="https://registry.npmmirror.com/-/binary/git-for-windows/v2.39.2.windows.1/Git-2.39.2-64-bit.exe" />
 			<local:MyButton MinWidth="140" Padding="13,0" Margin="0,0,20,0" HorizontalAlignment="Left"
                         Text="访问官网" EventType="打开网页" EventData="https://git-scm.com/" />
 			<local:MyButton MinWidth="140" Padding="13,0" Margin="0,0,20,0" HorizontalAlignment="Left"


### PR DESCRIPTION
好吧，我的“下载 Git”按钮文字被覆盖掉了（）

主要就是把“点击下载”改成了“下载”……感觉“点击”两个字没啥必要……

还有，这次绝对不可能覆盖掉下载链接了……