### PR TITLE
更改购买正版链接

### DIFF
--- a/Minecraft/购买正版.json
+++ b/Minecraft/购买正版.json
@@ -1,10 +1,10 @@
 {
 	"__Author__": "Wind_64",
 	"Title": "购买 Minecraft 正版",
-	"Description": "前往 Mojang 官网购买正版《我的世界》",
+	"Description": "前往 Xbox 购买正版《我的世界》",
 	"Types": [ "Minecraft" ],
 	"IsEvent": true,
 	"Keywords": "入正",
 	"EventType": "打开网页",
-	"EventData": "https://www.minecraft.net/store/checkout/minecraft-java-bedrock-edition-pc"
+	"EventData": "https://www.xbox.com/zh-cn/games/store/minecraft-java-bedrock-edition-for-pc/9nxp44l49shj"
 }


### PR DESCRIPTION
由于 Hex-Dragon/PCL2#1806 提及原因，将帮助库购买正版链接进行同步。由 Minecraft 官网调整至 Xbox。