### PR TITLE
统一教程步骤排版格式及细节优化

### DIFF
--- a/Minecraft/微软账号登录失败.xaml
+++ b/Minecraft/微软账号登录失败.xaml
@@ -98,43 +98,5 @@
     </StackPanel>
 </local:MyCard>
 
-<!-- 第二种问题解决方案 -->
-<local:MyCard Title="第二种问题解决方案" CanSwap="True" IsSwaped="True">
-    <StackPanel Margin="25,40,23,11">
-        <!-- 此处我存疑，部分台式电脑无无线局域网功能 -->
-        <TextBlock Margin="0,10,0,2" LineHeight="17"
-            Text="1. 打开手机的移动热点功能，电脑连接热点。" />
-        <!-- win+R，打开运行界面，输入services.msc进入服务 -->
-        <TextBlock Margin="0,10,0,2" LineHeight="17"
-            Text="2. 按下键盘上的 Windows + R 键，打开运行界面，输入 services.msc 打开服务管理程序。" />            
-        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="https://cdn.img.z0z0r4.top/2022/07/10/1/10.Service.png" />
-        <local:MyButton MinWidth="170" Height="35" Padding="10,0" Margin="0,5,20,8" HorizontalAlignment="Left"
-        Text="复制 services.msc 命令" EventType="复制文本" EventData="services.msc" />
-
-        <!-- 功能开启 -->
-        <TextBlock Margin="0,10,0,2" LineHeight="17"
-            Text="3. 找到&quot;Microsoft (R) 诊断中心标准收集器服务&quot;，右键点击属性，改成手动，开启服务。" />    
-        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="https://cdn.img.z0z0r4.top/2022/07/10/1/11.Microsoft(R).png" />
-        <TextBlock Margin="0,10,0,2" LineHeight="17"
-            Text="4. 在任务栏上找到对应网络状态的图标，右键点击此图标后&quot;网络和 Internet 设置&quot;。" />
-        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="https://cdn.img.z0z0r4.top/2022/07/10/1/Taskbar.NI.Settings.png" />
-        <!-- 更改适配器设置 -->
-        <TextBlock Margin="0,10,0,2" LineHeight="17"
-            Text="5. Win10: 转到 WLAN 页面并点击&quot;更改适配器设置&quot;（在右边或者下边）。&#xA; Win11: 点击&quot;高级网络设置&quot;后点击下方的&quot;更多网络适配器选项&quot;。" />
-        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="https://cdn.img.z0z0r4.top/2022/07/10/1/3.WALN.png" />
-        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="https://cdn.img.z0z0r4.top/2022/07/10/1/Win11.Settings.NW.SPQ.png" />
-        <!-- 右键点击你的连接 点击属性 -->
-        <TextBlock Margin="0,10,0,2" LineHeight="17"
-            Text="6. 右键选择你的连接，点击属性。" />
-        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="https://cdn.img.z0z0r4.top/2022/07/10/1/4R.png" />
-        <TextBlock Margin="0,10,0,2" LineHeight="17"
-            Text="7. 双击“Internet 协议版本 4 (TCP/IPv4)”，点击使用下面的 DNS 服务器地址，在“首选 DNS 服务器”内填写“223.5.5.5”，在“备用 DNS 服务器”内填写“223.6.6.6”，您也可选择其他国内知名 DNS 提供商提供的 DNS (如 DNSPod)。保存后按住键盘上的 Windows 键 + R 键，输入“ipconfig /flushdns”以刷新 DNS 缓存，接着再次进入 PCL2 启动游戏即可正常登录。" />
-        <!-- 此处原 DNS 为微软公用 DNS，鉴于此 DNS 在中国大陆内使用情况不佳，更改为阿里云 DNS -->
-        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="https://cdn.img.z0z0r4.top/2022/07/10/1/ControlPanel.DNS.Settings.png" />
-        <local:MyButton MinWidth="170" Height="35" Padding="10,0" Margin="0,5,20,8" HorizontalAlignment="Left"
-        Text="复制 ipconfig /flushdns 命令" EventType="复制文本" EventData="ipconfig /flushdns" />
-    </StackPanel>
-</local:MyCard>
-
 <local:MyHint Margin="0,0,0,15" Text="作者：Dong_Yi_feng、WTP016" IsWarn="False" />
 

--- a/Minecraft/微软账号登录失败.xaml
+++ b/Minecraft/微软账号登录失败.xaml
@@ -20,7 +20,7 @@
             <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/26/6/Taskbar.NI.Settings.png" />
         </Grid>
         <!-- 更改适配器设置 -->
-        <Grid Margin="0,10,0,0">
+        <Grid Margin="0,20,0,4">
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
                         Text="2. Win10: 转到&quot;状态&quot;页面并点击&quot;更改适配器设置&quot;。&#xA; Win11: 点击&quot;高级网络设置&quot;后点击下方的&quot;更多网络适配器选项&quot;。" HorizontalAlignment="Left" />
             <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/25/6/Adopt_Settings.png" />
@@ -34,13 +34,19 @@
             <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/25/6/Network_Settings.png" />
         </Grid>
 
-        <Grid Margin="0,20,0,4">
+        <local:MyHint Margin="0,20,0,0" Text="您也可选择其他国内知名 DNS 提供商提供的 DNS (如 DNSPod)。" IsWarn="False" />
+        <Grid Margin="0,10,0,0">
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
-                        Text="4. 双击“Internet 协议版本 4 (TCP/IPv4)”，点击使用下面的 DNS 服务器地址，在“首选 DNS 服务器”内填写“223.5.5.5”，在“备用 DNS 服务器”内填写“223.6.6.6”，您也可选择其他国内知名 DNS 提供商提供的 DNS (如 DNSPod)。保存后按住键盘上的 Windows 键 + R 键，输入“ipconfig /flushdns”以刷新 DNS 缓存，接着再次进入 PCL2 启动游戏即可正常登录。" HorizontalAlignment="Left" />
+                        Text="4. 双击“Internet 协议版本 4 (TCP/IPv4)”，点击使用下面的 DNS 服务器地址，在“首选 DNS 服务器”内填写“223.5.5.5”，在“备用 DNS 服务器”内填写“223.6.6.6”并保存。" HorizontalAlignment="Left" />
             <!-- 此处原 DNS 为微软公用 DNS，鉴于此 DNS 在中国大陆内使用情况不佳，更改为阿里云 DNS -->
             <local:MyButton MinWidth="170" Height="35" Padding="10,0" Margin="0,5,20,8" HorizontalAlignment="Left"
                         Text="复制 ipconfig /flushdns 命令" EventType="复制文本" EventData="ipconfig /flushdns" />
             <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/26/6/ControlPanel.DNS.Settings.png" />
+        </Grid>
+
+        <Grid Margin="0,20,0,4">
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4"
+                        Text="5. 按住键盘上的 Windows 键 + R 键，输入“ipconfig /flushdns”以刷新 DNS 缓存，接着再次进入 PCL2 启动游戏即可正常登录。" />
         </Grid>
     </StackPanel>
 </local:MyCard>
@@ -50,11 +56,11 @@
 	<StackPanel Margin="25,40,23,15">
         <!-- 此处我存疑，部分台式电脑无无线局域网功能 -->
         <Grid>
-            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4"
                         Text="1. 打开手机的移动热点功能，电脑连接热点。"/>
         </Grid>
         <!-- win+R，打开运行界面，输入services.msc进入服务 -->
-        <Grid Margin="0,10,0,0">
+        <Grid Margin="0,20,0,4">
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
                         Text="2. 按下键盘上的 Windows + R 键，打开运行界面，输入 services.msc 打开服务管理程序。" HorizontalAlignment="Left" />
             <local:MyButton MinWidth="170" Height="35" Padding="10,0" Margin="0,5,20,8" HorizontalAlignment="Left"
@@ -87,13 +93,19 @@
             <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/10/1/4R.png" />
         </Grid>
 
-        <Grid Margin="0,20,0,4">
+        <local:MyHint Margin="0,20,0,0" Text="您也可选择其他国内知名 DNS 提供商提供的 DNS (如 DNSPod)。" IsWarn="False" />
+        <Grid Margin="0,10,0,0">
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
-                        Text="4. 双击“Internet 协议版本 4 (TCP/IPv4)”，点击使用下面的 DNS 服务器地址，在“首选 DNS 服务器”内填写“223.5.5.5”，在“备用 DNS 服务器”内填写“223.6.6.6”，您也可选择其他国内知名 DNS 提供商提供的 DNS (如 DNSPod)。保存后按住键盘上的 Windows 键 + R 键，输入“ipconfig /flushdns”以刷新 DNS 缓存，接着再次进入 PCL2 启动游戏即可正常登录。" HorizontalAlignment="Left" />
+                        Text="4. 双击“Internet 协议版本 4 (TCP/IPv4)”，点击使用下面的 DNS 服务器地址，在“首选 DNS 服务器”内填写“223.5.5.5”，在“备用 DNS 服务器”内填写“223.6.6.6”并保存。" HorizontalAlignment="Left" />
             <!-- 此处原 DNS 为微软公用 DNS，鉴于此 DNS 在中国大陆内使用情况不佳，更改为阿里云 DNS -->
             <local:MyButton MinWidth="170" Height="35" Padding="10,0" Margin="0,5,20,8" HorizontalAlignment="Left"
                         Text="复制 ipconfig /flushdns 命令" EventType="复制文本" EventData="ipconfig /flushdns" />
             <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/26/6/ControlPanel.DNS.Settings.png" />
+        </Grid>
+
+        <Grid Margin="0,20,0,4">
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4"
+                        Text="5. 按住键盘上的 Windows 键 + R 键，输入“ipconfig /flushdns”以刷新 DNS 缓存，接着再次进入 PCL2 启动游戏即可正常登录。" />
         </Grid>
     </StackPanel>
 </local:MyCard>

--- a/Minecraft/微软账号登录失败.xaml
+++ b/Minecraft/微软账号登录失败.xaml
@@ -39,8 +39,6 @@
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
                         Text="4. 双击“Internet 协议版本 4 (TCP/IPv4)”，点击使用下面的 DNS 服务器地址，在“首选 DNS 服务器”内填写“223.5.5.5”，在“备用 DNS 服务器”内填写“223.6.6.6”并保存。" HorizontalAlignment="Left" />
             <!-- 此处原 DNS 为微软公用 DNS，鉴于此 DNS 在中国大陆内使用情况不佳，更改为阿里云 DNS -->
-            <local:MyButton MinWidth="170" Height="35" Padding="10,0" Margin="0,5,20,8" HorizontalAlignment="Left"
-                        Text="复制 ipconfig /flushdns 命令" EventType="复制文本" EventData="ipconfig /flushdns" />
             <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/26/6/ControlPanel.DNS.Settings.png" />
         </Grid>
 
@@ -48,6 +46,8 @@
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4"
                         Text="5. 按住键盘上的 Windows 键 + R 键，输入“ipconfig /flushdns”以刷新 DNS 缓存，接着再次进入 PCL2 启动游戏即可正常登录。" />
         </Grid>
+        <local:MyButton MinWidth="170" Height="35" Padding="10,0" Margin="0,5,20,8" HorizontalAlignment="Left"
+                        Text="复制 ipconfig /flushdns 命令" EventType="复制文本" EventData="ipconfig /flushdns" />
     </StackPanel>
 </local:MyCard>
 
@@ -98,8 +98,6 @@
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
                         Text="4. 双击“Internet 协议版本 4 (TCP/IPv4)”，点击使用下面的 DNS 服务器地址，在“首选 DNS 服务器”内填写“223.5.5.5”，在“备用 DNS 服务器”内填写“223.6.6.6”并保存。" HorizontalAlignment="Left" />
             <!-- 此处原 DNS 为微软公用 DNS，鉴于此 DNS 在中国大陆内使用情况不佳，更改为阿里云 DNS -->
-            <local:MyButton MinWidth="170" Height="35" Padding="10,0" Margin="0,5,20,8" HorizontalAlignment="Left"
-                        Text="复制 ipconfig /flushdns 命令" EventType="复制文本" EventData="ipconfig /flushdns" />
             <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/26/6/ControlPanel.DNS.Settings.png" />
         </Grid>
 
@@ -107,6 +105,8 @@
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4"
                         Text="5. 按住键盘上的 Windows 键 + R 键，输入“ipconfig /flushdns”以刷新 DNS 缓存，接着再次进入 PCL2 启动游戏即可正常登录。" />
         </Grid>
+        <local:MyButton MinWidth="170" Height="35" Padding="10,0" Margin="0,5,20,8" HorizontalAlignment="Left"
+                        Text="复制 ipconfig /flushdns 命令" EventType="复制文本" EventData="ipconfig /flushdns" />
     </StackPanel>
 </local:MyCard>
 

--- a/Minecraft/微软账号登录失败.xaml
+++ b/Minecraft/微软账号登录失败.xaml
@@ -12,27 +12,36 @@
     </StackPanel>
 </local:MyCard>
 
-<local:MyCard Title="问题解决方案" CanSwap="True" IsSwaped="True">
-    <StackPanel Margin="25,40,23,11">
-        <TextBlock Margin="0,10,0,2" LineHeight="17"
-            Text="1. 在任务栏上找到对应网络状态的图标，右键点击此图标后点击&quot;网络和 Internet 设置&quot;。" />
-        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="https://cdn.img.z0z0r4.top/2022/07/26/6/Taskbar.NI.Settings.png" />
+<local:MyCard Title="问题解决方案" Margin="0,0,0,15" CanSwap="True" IsSwaped="True">
+	<StackPanel Margin="25,40,23,15">
+        <Grid>
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
+                        Text="1. 在任务栏上找到对应网络状态的图标，右键点击此图标后点击&quot;网络和 Internet 设置&quot;。" HorizontalAlignment="Left" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/26/6/Taskbar.NI.Settings.png" />
+        </Grid>
         <!-- 更改适配器设置 -->
-        <TextBlock Margin="0,10,0,2" LineHeight="17"
-            Text="2. Win10: 转到&quot;状态&quot;页面并点击&quot;更改适配器设置&quot;。&#xA; Win11: 点击&quot;高级网络设置&quot;后点击下方的&quot;更多网络适配器选项&quot;。" />
-        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="https://cdn.img.z0z0r4.top/2022/07/25/6/Adopt_Settings.png" />
-        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="https://cdn.img.z0z0r4.top/2022/07/26/6/Win11.Settings.NW.SPQ.png" />
+        <Grid Margin="0,10,0,0">
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
+                        Text="2. Win10: 转到&quot;状态&quot;页面并点击&quot;更改适配器设置&quot;。&#xA; Win11: 点击&quot;高级网络设置&quot;后点击下方的&quot;更多网络适配器选项&quot;。" HorizontalAlignment="Left" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/25/6/Adopt_Settings.png" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/26/6/Win11.Settings.NW.SPQ.png" />
+        </Grid>
         <!-- 右键点击你的连接 点击属性 -->
-        <TextBlock Margin="0,10,0,2" LineHeight="17"
-            Text="3. 右键点击您目前正在连接的网络（一般为&quot;以太网&quot;或&quot;WLAN&quot;），点击属性。" />
-        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="https://cdn.img.z0z0r4.top/2022/07/10/1/4R.png" />
-        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="https://cdn.img.z0z0r4.top/2022/07/25/6/Network_Settings.png" />
-        <TextBlock Margin="0,10,0,2" LineHeight="17"
-            Text="4. 双击“Internet 协议版本 4 (TCP/IPv4)”，点击使用下面的 DNS 服务器地址，在“首选 DNS 服务器”内填写“223.5.5.5”，在“备用 DNS 服务器”内填写“223.6.6.6”，您也可选择其他国内知名 DNS 提供商提供的 DNS (如 DNSPod)。保存后按住键盘上的 Windows 键 + R 键，输入“ipconfig /flushdns”以刷新 DNS 缓存，接着再次进入 PCL2 启动游戏即可正常登录。" />
-        <!-- 此处原 DNS 为微软公用 DNS，鉴于此 DNS 在中国大陆内使用情况不佳，更改为阿里云 DNS -->
-        <Image HorizontalAlignment="Center" Margin="50,15,50,0" Source="https://cdn.img.z0z0r4.top/2022/07/26/6/ControlPanel.DNS.Settings.png" />
-        <local:MyButton MinWidth="170" Height="35" Padding="10,0" Margin="0,5,20,8" HorizontalAlignment="Left"
-        Text="复制 ipconfig /flushdns 命令" EventType="复制文本" EventData="ipconfig /flushdns" />
+        <Grid Margin="0,20,0,4">
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
+                        Text="3. 右键点击您目前正在连接的网络（一般为&quot;以太网&quot;或&quot;WLAN&quot;），点击属性。" HorizontalAlignment="Left" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/10/1/4R.png" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/25/6/Network_Settings.png" />
+        </Grid>
+
+        <Grid Margin="0,20,0,4">
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
+                        Text="4. 双击“Internet 协议版本 4 (TCP/IPv4)”，点击使用下面的 DNS 服务器地址，在“首选 DNS 服务器”内填写“223.5.5.5”，在“备用 DNS 服务器”内填写“223.6.6.6”，您也可选择其他国内知名 DNS 提供商提供的 DNS (如 DNSPod)。保存后按住键盘上的 Windows 键 + R 键，输入“ipconfig /flushdns”以刷新 DNS 缓存，接着再次进入 PCL2 启动游戏即可正常登录。" HorizontalAlignment="Left" />
+            <!-- 此处原 DNS 为微软公用 DNS，鉴于此 DNS 在中国大陆内使用情况不佳，更改为阿里云 DNS -->
+            <local:MyButton MinWidth="170" Height="35" Padding="10,0" Margin="0,5,20,8" HorizontalAlignment="Left"
+                        Text="复制 ipconfig /flushdns 命令" EventType="复制文本" EventData="ipconfig /flushdns" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/26/6/ControlPanel.DNS.Settings.png" />
+        </Grid>
     </StackPanel>
 </local:MyCard>
 

--- a/Minecraft/微软账号登录失败.xaml
+++ b/Minecraft/微软账号登录失败.xaml
@@ -110,5 +110,5 @@
     </StackPanel>
 </local:MyCard>
 
-<local:MyHint Margin="0,0,0,15" Text="作者：Dong_Yi_feng、WTP016" IsWarn="False" />
+<local:MyHint Margin="0,0,0,15" Text="作者：Dong_Yi_feng、WTP016、风释清然SC" IsWarn="False" />
 

--- a/Minecraft/微软账号登录失败.xaml
+++ b/Minecraft/微软账号登录失败.xaml
@@ -12,7 +12,7 @@
     </StackPanel>
 </local:MyCard>
 
-<local:MyCard Title="问题解决方案" Margin="0,0,0,15" CanSwap="True" IsSwaped="True">
+<local:MyCard Title="第一种问题解决方案" Margin="0,0,0,15" CanSwap="True" IsSwaped="True">
 	<StackPanel Margin="25,40,23,15">
         <Grid>
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
@@ -32,6 +32,59 @@
                         Text="3. 右键点击您目前正在连接的网络（一般为&quot;以太网&quot;或&quot;WLAN&quot;），点击属性。" HorizontalAlignment="Left" />
             <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/10/1/4R.png" />
             <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/25/6/Network_Settings.png" />
+        </Grid>
+
+        <Grid Margin="0,20,0,4">
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
+                        Text="4. 双击“Internet 协议版本 4 (TCP/IPv4)”，点击使用下面的 DNS 服务器地址，在“首选 DNS 服务器”内填写“223.5.5.5”，在“备用 DNS 服务器”内填写“223.6.6.6”，您也可选择其他国内知名 DNS 提供商提供的 DNS (如 DNSPod)。保存后按住键盘上的 Windows 键 + R 键，输入“ipconfig /flushdns”以刷新 DNS 缓存，接着再次进入 PCL2 启动游戏即可正常登录。" HorizontalAlignment="Left" />
+            <!-- 此处原 DNS 为微软公用 DNS，鉴于此 DNS 在中国大陆内使用情况不佳，更改为阿里云 DNS -->
+            <local:MyButton MinWidth="170" Height="35" Padding="10,0" Margin="0,5,20,8" HorizontalAlignment="Left"
+                        Text="复制 ipconfig /flushdns 命令" EventType="复制文本" EventData="ipconfig /flushdns" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/26/6/ControlPanel.DNS.Settings.png" />
+        </Grid>
+    </StackPanel>
+</local:MyCard>
+
+<!-- 第二种问题解决方案 -->
+<local:MyCard Title="第二种问题解决方案" Margin="0,0,0,15" CanSwap="True" IsSwaped="True">
+	<StackPanel Margin="25,40,23,15">
+        <!-- 此处我存疑，部分台式电脑无无线局域网功能 -->
+        <Grid>
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
+                        Text="1. 打开手机的移动热点功能，电脑连接热点。"/>
+        </Grid>
+        <!-- win+R，打开运行界面，输入services.msc进入服务 -->
+        <Grid Margin="0,10,0,0">
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
+                        Text="2. 按下键盘上的 Windows + R 键，打开运行界面，输入 services.msc 打开服务管理程序。" HorizontalAlignment="Left" />
+            <local:MyButton MinWidth="170" Height="35" Padding="10,0" Margin="0,5,20,8" HorizontalAlignment="Left"
+                        Text="复制 services.msc 命令" EventType="复制文本" EventData="services.msc" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/10/1/10.Service.png" />
+        </Grid>
+        <!-- 功能开启 -->
+        <Grid Margin="0,20,0,4">
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
+                        Text="3. 找到&quot;Microsoft (R) 诊断中心标准收集器服务&quot;，右键点击属性，改成手动，开启服务。" HorizontalAlignment="Left" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/10/1/11.Microsoft(R).png" />
+        </Grid>
+
+        <Grid Margin="0,20,0,4">
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
+                        Text="4. 在任务栏上找到对应网络状态的图标，右键点击此图标后&quot;网络和 Internet 设置&quot;。" HorizontalAlignment="Left" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/10/1/Taskbar.NI.Settings.png" />
+        </Grid>
+        <!-- 更改适配器设置 -->
+        <Grid Margin="0,10,0,0">
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
+                        Text="2. Win10: 转到&quot;状态&quot;页面并点击&quot;更改适配器设置&quot;。&#xA; Win11: 点击&quot;高级网络设置&quot;后点击下方的&quot;更多网络适配器选项&quot;。" HorizontalAlignment="Left" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/25/6/Adopt_Settings.png" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/26/6/Win11.Settings.NW.SPQ.png" />
+        </Grid>
+        <!-- 右键点击你的连接 点击属性 -->
+        <Grid Margin="0,20,0,4">
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
+                        Text="3. 右键点击您目前正在连接的网络（一般为&quot;以太网&quot;或&quot;WLAN&quot;），点击属性。" HorizontalAlignment="Left" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/10/1/4R.png" />
         </Grid>
 
         <Grid Margin="0,20,0,4">

--- a/Minecraft/设置分配内存大小.xaml
+++ b/Minecraft/设置分配内存大小.xaml
@@ -3,43 +3,68 @@
 
 <local:MyCard Title="手动设置内存大小">
 	<StackPanel Margin="25,40,23,5">
+    <local:MyHint Margin="0,-3,0,10" Text="请注意，错误的内存分配会造成游戏不稳定甚至不正常的内存溢出。请在自行修改内存前务必谨慎操作！"/>
 		<TextBlock Margin="0,0,0,4" LineHeight="17"
                    Text="在某些情况下，自动分配内存可能会出现一些难以预知的问题。&#xa;因此，在自动分配无法正常工作时，手动设置内存就十分必要。&#xa;本教程针对独立版本调整和全局设定两种途径进行讨论。"/>
-    <local:MyHint Margin="0,-5,0,15" Text="请注意，错误的内存分配会造成游戏不稳定甚至不正常的内存溢出。&#xa;请在自行修改内存前务必谨慎操作！"/>
 	</StackPanel>
 </local:MyCard>
 
-<local:MyCard Title="1. 针对独立的一个版本进行调整">
-    <StackPanel Margin="25,40,23,15">   
-        <TextBlock Margin="0,4,0,4" LineHeight="20"
-                   Text="1. 打开您的 PCL2 启动器，在主页点击左下方的“版本选择”按钮。" />
-        <Image HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2023/01/17/63c65b027e9d1.jpg" />                   
-        <TextBlock Margin="0,4,0,4" LineHeight="20"
-                   Text="2. 在版本选择列表中，右键点击需要修改内存的游戏版本。" />
-        <Image HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2023/01/17/63c65b062580e.jpg" />
-        <TextBlock Margin="0,4,0,4" LineHeight="20"
-                   Text="3. 在该版本的设置中，点击左侧的“设置”选项卡。" />
-        <Image HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2023/01/17/63c65b04a32eb.jpg" />        
-        <TextBlock Margin="0,4,0,4" LineHeight="20"
-                   Text="4. 滑动至下方，找到“游戏内存”选项卡，选择“自定义”，然后滑动圆点即可手动调整。&#xa;此时，该版本的启动内存已为固定值，不再自动变更。" />
-        <Image HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2023/01/17/63c65b018c28c.jpg" />    
+<local:MyCard Title="针对独立版本进行调整" Margin="0,0,0,15">
+	<StackPanel Margin="25,40,23,15">
+        <Grid>
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
+                        Text="1. 打开您的 PCL2 启动器，在主页点击左下方的“版本选择”按钮。" HorizontalAlignment="Left" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2023/01/17/63c65b027e9d1.jpg" />
+        </Grid>
+
+        <Grid Margin="0,20,0,4">
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
+                        Text="2. 在左侧页面中通过选择或输入您所需 Mod 的名称、类型、来源、游戏版本及其需要的加载器类型以筛选并搜索整合包。" HorizontalAlignment="Left" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2023/04/09/6432ac35f0f42.png?comment=Mod搜索筛选选项" />
+        </Grid>
+
+        <Grid Margin="0,20,0,4">
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
+                        Text="2. 在版本选择列表中，右键点击需要修改内存的游戏版本。" HorizontalAlignment="Left" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2023/01/17/63c65b062580e.jpg" />
+        </Grid>
+
+        <Grid Margin="0,20,0,4">
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
+                        Text="3. 在该版本的设置中，点击左侧的“设置”选项卡。" HorizontalAlignment="Left" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2023/01/17/63c65b04a32eb.jpg" />
+        </Grid>
+
+        <Grid Margin="0,20,0,4">
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
+                        Text="4. 滑动至下方，找到“游戏内存”选项卡，选择“自定义”，然后滑动圆点即可手动调整。&#xa;此时，该版本的启动内存已为固定值，不再自动变更。" HorizontalAlignment="Left" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2023/01/17/63c65b018c28c.jpg" />
+        </Grid>
     </StackPanel>
 </local:MyCard>
 
 <!-- 原图床已经无法正常加载，补充图床 -->
 <!-- 有时候能加在出来有时候不能加载，而且加载了不能同时加载，更换图床 -->
 <!-- 已更改图床，并根据规范修改图片，by ITfool（Github）2023.1.15-->
-<local:MyCard Title="2. 针对启动器所有游戏内存进行调整">
-    <StackPanel Margin="25,40,23,15">   
-		<local:MyHint Margin="0,-5,0,15" Text="请注意，修改 PCL2 的全局配置将影响所有依赖 PCL2 启动的游戏版本。"/>
-        <TextBlock Margin="0,0,0,4" LineHeight="20"
-                   Text="1. 打开您的 PCL2 启动器，在主页点击上方的“设置”选单。" />
-        <Image HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2023/01/17/63c65b0531ff2.jpg" />                   
-        <TextBlock Margin="0,4,0,4" LineHeight="20"
-                   Text="2. 点击左侧的“游戏”选项卡，向下翻找，找到“游戏内存”选项卡。" />
-        <Image HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2023/01/17/63c65b0049d45.jpg" />
-        <TextBlock Margin="0,4,0,4" LineHeight="20"
-                   Text="3. 选择“自定义”，此时拖动圆点即可手动调整全局内存。" />
+<local:MyCard Title="针对独立版本进行调整" Margin="0,0,0,15">
+	<StackPanel Margin="25,40,23,15">
+        <local:MyHint Margin="0,-3,0,10" Text="请注意，修改 PCL2 的全局配置将影响所有依赖 PCL2 启动的游戏版本。"/>
+        <Grid>
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
+                        Text="1. 打开您的 PCL2 启动器，在主页点击上方的“设置”选单。" HorizontalAlignment="Left" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2023/01/17/63c65b0531ff2.jpg" />
+        </Grid>
+
+        <Grid Margin="0,20,0,4">
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
+                        Text="2. 点击左侧的“游戏”选项卡，向下翻找，找到“游戏内存”选项卡。" HorizontalAlignment="Left" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2023/01/17/63c65b0049d45.jpg" />
+        </Grid>
+
+        <Grid Margin="0,20,0,4">
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4"
+                        Text="3. 选择“自定义”，此时拖动圆点即可手动调整全局内存。"/>
+        </Grid>
     </StackPanel>
 </local:MyCard>
 

--- a/Minecraft/设置分配内存大小.xaml
+++ b/Minecraft/设置分配内存大小.xaml
@@ -4,7 +4,7 @@
 <local:MyCard Title="手动设置内存大小">
 	<StackPanel Margin="25,40,23,5">
     <local:MyHint Margin="0,-3,0,10" Text="请注意，错误的内存分配会造成游戏不稳定甚至不正常的内存溢出。请在自行修改内存前务必谨慎操作！"/>
-		<TextBlock Margin="0,0,0,4" LineHeight="17"
+		<TextBlock Margin="0,0,0,10" LineHeight="17"
                    Text="在某些情况下，自动分配内存可能会出现一些难以预知的问题。&#xa;因此，在自动分配无法正常工作时，手动设置内存就十分必要。&#xa;本教程针对独立版本调整和全局设定两种途径进行讨论。"/>
 	</StackPanel>
 </local:MyCard>
@@ -48,7 +48,7 @@
 <!-- 已更改图床，并根据规范修改图片，by ITfool（Github）2023.1.15-->
 <local:MyCard Title="针对独立版本进行调整" Margin="0,0,0,15">
 	<StackPanel Margin="25,40,23,15">
-        <local:MyHint Margin="0,-3,0,10" Text="请注意，修改 PCL2 的全局配置将影响所有依赖 PCL2 启动的游戏版本。"/>
+        <local:MyHint Margin="0,0,0,10" Text="请注意，修改 PCL2 的全局配置将影响所有依赖 PCL2 启动的游戏版本。"/>
         <Grid>
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
                         Text="1. 打开您的 PCL2 启动器，在主页点击上方的“设置”选单。" HorizontalAlignment="Left" />

--- a/Minecraft/设置分配内存大小.xaml
+++ b/Minecraft/设置分配内存大小.xaml
@@ -19,12 +19,6 @@
 
         <Grid Margin="0,20,0,4">
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
-                        Text="2. 在左侧页面中通过选择或输入您所需 Mod 的名称、类型、来源、游戏版本及其需要的加载器类型以筛选并搜索整合包。" HorizontalAlignment="Left" />
-            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2023/04/09/6432ac35f0f42.png?comment=Mod搜索筛选选项" />
-        </Grid>
-
-        <Grid Margin="0,20,0,4">
-            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
                         Text="2. 在版本选择列表中，右键点击需要修改内存的游戏版本。" HorizontalAlignment="Left" />
             <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2023/01/17/63c65b062580e.jpg" />
         </Grid>
@@ -46,7 +40,7 @@
 <!-- 原图床已经无法正常加载，补充图床 -->
 <!-- 有时候能加在出来有时候不能加载，而且加载了不能同时加载，更换图床 -->
 <!-- 已更改图床，并根据规范修改图片，by ITfool（Github）2023.1.15-->
-<local:MyCard Title="针对独立版本进行调整" Margin="0,0,0,15">
+<local:MyCard Title="针对全局版本进行调整" Margin="0,0,0,15">
 	<StackPanel Margin="25,40,23,15">
         <local:MyHint Margin="0,0,0,10" Text="请注意，修改 PCL2 的全局配置将影响所有依赖 PCL2 启动的游戏版本。"/>
         <Grid>

--- a/启动器/LittleSkin 外置登录使用教程.json
+++ b/启动器/LittleSkin 外置登录使用教程.json
@@ -1,5 +1,5 @@
 {
-    "__Author__": "一闪、呇星、EggPixel",
+    "__Author__": "一闪、呇星、EggPixel、风释清然SC",
     "Title": "设置 LittleSkin 的外置登录",
     "Description": "用于非正版联机，或者用于使用 LittleSkin 网站的皮肤",
     "Types": ["启动器"]

--- a/启动器/LittleSkin 外置登录使用教程.xaml
+++ b/启动器/LittleSkin 外置登录使用教程.xaml
@@ -11,41 +11,66 @@
     </StackPanel>
 </local:MyCard>
 
-<local:MyCard Title="教程">
-    <StackPanel Margin="25,40,23,15">
-        <local:MyHint Margin="0,10,0,0" Text="以下填写的所有邮箱地址应全部为英文小写字母，否则将会出现 UUID 为 null 的情况导致无法进入服务器！" IsWarn="True" />
-        
-        <TextBlock Margin="0,10,0,0" Text="1. 前往 LittleSkin 注册一个账号。" />
+<local:MyCard Title="设置 Little Skin 外置登录" Margin="0,0,0,15">
+	<StackPanel Margin="25,40,23,15">
+        <local:MyHint Margin="0,-3,0,0" Text="以下填写的所有邮箱地址应全部为英文小写字母，否则将会出现 UUID 为 null 的情况导致无法进入服务器！"/>
+        <local:MyButton Margin="0,15,0,0" MinWidth="140" Padding="13,0" HorizontalAlignment="Left" Height="35" 
+                        Text="打开 LittleSkin" EventType="打开网页" EventData="https://littleskin.cn" />
         <local:MyHint Margin="0,10,0,0" Text="在注册 LittleSkin 账号时不要使用第三方登录，可能会导致账号无法设置密码，从而无法继续操作！" IsWarn="False" />
-        <local:MyButton Margin="0,10,0,0" MinWidth="140" Padding="13,0" HorizontalAlignment="Left" Height="35" Text="打开 LittleSkin 注册界面" EventType="打开网页" EventData="https://littleskin.cn/auth/register" />
-        <Image Margin="0,10,0,0" Height="360" HorizontalAlignment="Left" Source ="https://cdn.img.z0z0r4.top/2022/07/10/1/img1.png" />
+        <Grid Margin="0,10,0,0">
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
+                        Text="1. 前往 LittleSkin 注册一个账号。" HorizontalAlignment="Left" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2023/05/15/64623b15ae134.png" />
+        </Grid>
 
-        <TextBlock Margin="0,50,0,0" Text="2. 进入“仪表盘”，点击左侧“角色管理”，再点击“添加新角色”。" />
-        <local:MyButton Margin="0,10,0,0" MinWidth="140" Padding="13,0" HorizontalAlignment="Left" Height="35" Text="打开 LittleSkin 用户中心" EventType="打开网页" EventData="https://littleskin.cn/user" />
-        <Image Margin="0,10,0,0" Height="360" HorizontalAlignment="Left" Source="https://cdn.img.z0z0r4.top/2022/07/10/1/img2.png" />
+        <Grid Margin="0,20,0,4">
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
+                        Text="2. 进入“仪表盘”，点击左侧“角色管理”，再点击“添加新角色”。" HorizontalAlignment="Left" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/10/1/img2.png" />
+        </Grid>
 
-        <TextBlock Margin="0,50,0,0" Text="3. 在弹出的窗口内输入角色名（这将会成为联机时的 ID，即游戏中的用户名），填写完成后点击“确定”。" />
-        <Image Margin="0,20,0,0" Height="360" HorizontalAlignment="Left" Source="https://cdn.img.z0z0r4.top/2022/07/10/1/img3.png" />
+        <Grid Margin="0,20,0,4">
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
+                        Text="3. 在弹出的窗口内输入角色名（这将会成为联机时的 ID，即游戏中的用户名），填写完成后点击“确定”。" HorizontalAlignment="Left" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/10/1/img3.png" />
+        </Grid>
 
-        <TextBlock Margin="0,50,0,0" Text="4. 打开 PCL2，点击左下角的“版本选择”。" />
-        <Image Margin="0,20,0,0" Height="360" HorizontalAlignment="Left" Source="https://cdn.img.z0z0r4.top/2023/02/19/63f20230b5136.png" />
+        <Grid Margin="0,20,0,4">
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
+                        Text="4. 打开 PCL2，点击左下角的“版本选择”。" HorizontalAlignment="Left" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2023/02/19/63f20230b5136.png" />
+        </Grid>
 
-        <TextBlock Margin="0,50,0,0" Text="5. 右键点击将要启动的游戏版本。" />
-        <Image Margin="0,20,0,0" Height="360" HorizontalAlignment="Left"  Source="https://cdn.img.z0z0r4.top/2023/02/19/63f20230bedd5.png" />
+        <Grid Margin="0,20,0,4">
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
+                        Text="5. 右键点击将要启动的游戏版本。" HorizontalAlignment="Left" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2023/02/19/63f20230bedd5.png" />
+        </Grid>
 
-        <TextBlock Margin="0,50,0,0" Text="6. 点击左侧“设置”选项。" />
-        <Image Margin="0,20,0,0" Height="360" HorizontalAlignment="Left" Source="https://cdn.img.z0z0r4.top/2023/02/19/63f20230c9e9b.png" />
+        <Grid Margin="0,20,0,4">
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
+                        Text="6. 点击左侧“设置”选项。" HorizontalAlignment="Left" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2023/02/19/63f20230c9e9b.png" />
+        </Grid>
 
-        <TextBlock Margin="0,50,0,0" Text="7. 滑动到页面底部，在“服务器选项”中把登录方式设为“第三方登录：Authlib Injector 或 LittleSkin”" />   
-        <Image Margin="0,20,0,0" Height="360" HorizontalAlignment="Left" Source="https://cdn.img.z0z0r4.top/2023/02/20/63f36df35222d.png" />
+        <Grid Margin="0,20,0,4">
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
+                        Text="7. 滑动到页面底部，在“服务器选项”中把登录方式设为“第三方登录：Authlib Injector 或 LittleSkin”。" HorizontalAlignment="Left" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2023/02/20/63f36df35222d.png" />
+        </Grid>
 
-        <TextBlock Margin="0,50,0,0" Text="8. 点击下方“设置为 LittleSkin”按钮，并点击“确定”。" />   
-        <Image Margin="0,20,0,0" Height="360" HorizontalAlignment="Left" Source="https://cdn.img.z0z0r4.top/2023/02/20/63f36e0268931.png" />
+        <Grid Margin="0,20,0,4">
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
+                        Text="8. 点击下方“设置为 LittleSkin”按钮，并点击“确定”。" HorizontalAlignment="Left" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2023/02/20/63f36e0268931.png" />
+        </Grid>
 
-        <TextBlock Margin="0,50,0,0" Text="9. 返回主菜单并输入你的 LittleSkin 账号，点击“启动游戏”即可。" />   
-        <Image Margin="0,20,0,0" Height="360" HorizontalAlignment="Left" Source="https://cdn.img.z0z0r4.top/2023/02/20/63f36e13ba79e.png" />
-        
-        <TextBlock Margin="0,50,0,0" Text="在启动游戏后，PCL2 能够记忆你的账号，并且可以进行更换角色、更改皮肤、退出登录等操作。" />
+        <local:MyHint Margin="0,20,0,0" Text="在启动游戏后，PCL2 能够记忆你的账号，并且可以进行更换角色、更改皮肤、退出登录等操作。" IsWarn="False" />
+        <Grid Margin="0,10,0,0">
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
+                        Text="9. 返回主菜单并输入你的 LittleSkin 账号，点击“启动游戏”即可。" HorizontalAlignment="Left" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2023/02/20/63f36e13ba79e.png" />
+        </Grid>
     </StackPanel>
 </local:MyCard>
 

--- a/启动器/LittleSkin 外置登录使用教程.xaml
+++ b/启动器/LittleSkin 外置登录使用教程.xaml
@@ -7,15 +7,18 @@
         <TextBlock Margin="0,10,0,0" Text="如果您想用于联机，那么联机加入者必须是正版或外置登录，对房主则无要求。" />
         <TextBlock Margin="0,10,0,0" Text="如果您想在多人游戏中展示您的皮肤，请保证所有参与联机的成员均使用 LittleSkin 外置登录。皮肤显示不正常时，也可以搭配 CustomSkinLoader 模组并添加 ExtraList 文件以达到相同的效果。" />
         <local:MyHint Margin="0,10,0,0" Text="请注意：LittleSkin 外置登录不能用于进入正版服务器。" IsWarn="False" />
-        <local:MyButton Margin="0,10,0,0" MinWidth="280" Padding="13,0" HorizontalAlignment="Left" Height="35" Text="获取配置文件（须登录 LittleSkin）" EventType="打开网页" EventData="https://littleskin.cn/user/config" />
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+            <local:MyButton Margin="0,10,10,0" MinWidth="140" Padding="13,0" HorizontalAlignment="Left" Height="35" 
+                            Text="打开 LittleSkin" EventType="打开网页" EventData="https://littleskin.cn" />
+            <local:MyButton Margin="0,10,10,0" MinWidth="280" Padding="13,0" HorizontalAlignment="Left" Height="35" 
+                            Text="获取配置文件（须登录 LittleSkin）" EventType="打开网页" EventData="https://littleskin.cn/user/config" />
+        </StackPanel>
     </StackPanel>
 </local:MyCard>
 
 <local:MyCard Title="设置 Little Skin 外置登录" Margin="0,0,0,15">
 	<StackPanel Margin="25,40,23,15">
-        <local:MyHint Margin="0,-3,0,0" Text="以下填写的所有邮箱地址应全部为英文小写字母，否则将会出现 UUID 为 null 的情况导致无法进入服务器！"/>
-        <local:MyButton Margin="0,15,0,0" MinWidth="140" Padding="13,0" HorizontalAlignment="Left" Height="35" 
-                        Text="打开 LittleSkin" EventType="打开网页" EventData="https://littleskin.cn" />
+        <local:MyHint Margin="0,0,0,0" Text="以下填写的所有邮箱地址应全部为英文小写字母，否则将会出现 UUID 为 null 的情况导致无法进入服务器！"/>
         <local:MyHint Margin="0,10,0,0" Text="在注册 LittleSkin 账号时不要使用第三方登录，可能会导致账号无法设置密码，从而无法继续操作！" IsWarn="False" />
         <Grid Margin="0,10,0,0">
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
@@ -74,4 +77,4 @@
     </StackPanel>
 </local:MyCard>
 
-<local:MyHint Margin="0,0,0,15" Text="作者：一闪、呇星、EggPixel" IsWarn="False" />
+<local:MyHint Margin="0,0,0,15" Text="作者：一闪、呇星、EggPixel、风释清然SC" IsWarn="False" />

--- a/启动器/指定登录方式.xaml
+++ b/启动器/指定登录方式.xaml
@@ -1,14 +1,15 @@
 <!-- 需要根据规范重新整理格式、标点、空格等。部分语句不太通顺，需要再改改。 -->
 <!-- 图片备份 https://yshs.lanzoui.com/iIquToi85kf -->
 <!-- 2023/02/20 添加的图片 https://wwou.lanzoub.com/ijvOW0o1xrne 目前没有加箭头，可以加一下 -->
-<!--
+
 <local:MyCard Title="简介">
     <StackPanel Margin="25,40,23,15">
-        <TextBlock Margin="0,0,0,0" LineHeight="17" Text="PCL2 支持多种登录方式，例如正版登录、离线登录、统一通行证和 Authlib-Injector 登录，也可以单独为某一版本指定登录方式。此界面将提供简单的教程。" />
+        <TextBlock Margin="0,0,0,0" LineHeight="17" 
+                    Text="PCL2 目前支持正版登录、离线登录、统一通行证和 Authlib-Injector 登录，也可以单独为某一版本指定登录方式。本篇将对此提供简单的教程。" />
     </StackPanel>
 </local:MyCard>
--->
-<local:MyCard Title="步骤" Margin="0,0,0,15">
+
+<local:MyCard Title="指定登录方式" Margin="0,0,0,15">
 	<StackPanel Margin="25,40,23,15">
         <Grid>
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
@@ -36,7 +37,7 @@
     </StackPanel>
 </local:MyCard>
 
-<local:MyCard Title="设置 LittleSkin 登录">
+<local:MyCard Title="设置外置登录">
     <StackPanel Margin="25,40,23,15">
         <local:MyListItem Margin="0,0,0,0" EventType="打开帮助" EventData="启动器/LittleSkin 外置登录使用教程.json" />
     </StackPanel>

--- a/启动器/指定登录方式.xaml
+++ b/启动器/指定登录方式.xaml
@@ -8,19 +8,31 @@
     </StackPanel>
 </local:MyCard>
 -->
-<local:MyCard Title="教程">
-    <StackPanel Margin="25,40,23,15">
-        <TextBlock Margin="0,10,0,0" Text="1. 点击启动页面下方的“版本选择”。" />
-        <Image Height="360" Margin="0,20,0,0" HorizontalAlignment="Left" Source="https://cdn.img.z0z0r4.top/2023/02/19/63f20230b5136.png" />
+<local:MyCard Title="步骤" Margin="0,0,0,15">
+	<StackPanel Margin="25,40,23,15">
+        <Grid>
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
+                        Text="1. 点击启动页面下方的“版本选择”。" HorizontalAlignment="Left" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2023/02/19/63f20230b5136.png" />
+        </Grid>
 
-        <TextBlock Margin="0,50,0,0" Text="2. 右键点击需要修改的游戏版本。" />
-        <Image Height="360" Margin="0,20,0,0" HorizontalAlignment="Left" Source="https://cdn.img.z0z0r4.top/2023/02/19/63f20230c9e9b.png" />
+        <Grid Margin="0,20,0,4">
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
+                        Text="2. 右键点击需要修改的游戏版本。" HorizontalAlignment="Left" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2023/02/19/63f20230c9e9b.png" />
+        </Grid>
 
-        <TextBlock Margin="0,50,0,0" Text="3. 点击左侧“设置”按钮。" />
-        <Image Height="360" Margin="0,20,0,0" HorizontalAlignment="Left" Source="https://cdn.img.z0z0r4.top/2023/02/19/63f20230bedd5.png" />
-        
-        <TextBlock Margin="0,50,0,0" Text="4. 滑动至下方，在“服务器”中选择登录方式即可切换。" />
-        <Image Height="360" Margin="0,20,0,0" HorizontalAlignment="Left" Source="https://cdn.img.z0z0r4.top/2023/05/13/645f36c487851.png" />
+        <Grid Margin="0,20,0,4">
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
+                        Text="3. 点击左侧“设置”按钮。" HorizontalAlignment="Left" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2023/02/19/63f20230bedd5.png" />
+        </Grid>
+
+        <Grid Margin="0,20,0,4">
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
+                        Text="4. 滑动至下方，在“服务器”中选择登录方式即可切换。" HorizontalAlignment="Left" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2023/05/13/645f36c487851.png" />
+        </Grid>
     </StackPanel>
 </local:MyCard>
 

--- a/启动器/指定登录方式.xaml
+++ b/启动器/指定登录方式.xaml
@@ -20,7 +20,7 @@
         <Image Height="360" Margin="0,20,0,0" HorizontalAlignment="Left" Source="https://cdn.img.z0z0r4.top/2023/02/19/63f20230bedd5.png" />
         
         <TextBlock Margin="0,50,0,0" Text="4. 滑动至下方，在“服务器”中选择登录方式即可切换。" />
-        <Image Height="360" Margin="0,20,0,0" HorizontalAlignment="Left" Source="https://cdn.img.z0z0r4.top/2023/02/19/63f2023198b0c.png" />
+        <Image Height="360" Margin="0,20,0,0" HorizontalAlignment="Left" Source="https://cdn.img.z0z0r4.top/2023/05/13/645f36c487851.png" />
     </StackPanel>
 </local:MyCard>
 


### PR DESCRIPTION
### 前言
现有些页面的操作步骤展示有失美观性和清晰性，于是就将含有此问题的页面统一进行了更改，只有一步两步的页面我没有做更改；顺手也修改了一些这些页面的小细节问题（标点、措辞、图片）。因为更改内容非常多，而且还是分成好几天完成的，所以多多少少会出点错误，如果大家能帮我一起完善这个更改，真的非常感谢啦！

### 更改
#### Minecraft/微软账号登录失败.xaml
- **优化步骤排版**；
- 优化按钮位置；
- 拆分并优化部分步骤表述以避免文字长度过长；
- 调整部分文字至 MyHint。

#### Minecraft/设置分配内存大小.xaml
- **优化步骤排版**；
- 调整文首 MyHint 位置；
- 删除 MyCard 标题中的序号；
- 修改部分措辞以避免歧义。

#### 启动器/LittleSkin 外置登录使用教程.xaml
- 删除冗余按钮，将打开 LittleSkin 按钮合并至文首；
- **优化步骤排版**；
- 更新图片；
- 调整第九步文案至 MyHint。

#### 启动器/指定登录方式.xaml
- 在原有基础上修改并添加简介；
- **优化步骤排版**；
- 修改 MyCard 标题。

### 说明
- 对各个页面还进行了部分参数的调整使得视觉上平衡些；
- 部分修改我个人也不太确定其准确与合理性，可能需要大家一起帮忙仔细看看qwq……
- 因为整体而言我对内容的修改不算多，所以我只对两个更改较大的页面进行署名，如果有些页面中我的署名有失妥当还请指出🥳

###### 更改和提交比较多，所以麻烦大家耐心看看啦awa……