### PR TITLE
更新 角色皮肤导出 以适配 PCL 2.6.0+

### DIFF
--- a/启动器/角色皮肤导出.json
+++ b/启动器/角色皮肤导出.json
@@ -1,5 +1,5 @@
 {
-    "__Author__": "DreamUniverse",
+    "__Author__": "DreamUniverse、风释清然SC",
 	"Title": "导出角色皮肤",
 	"Description": "导出 Minecraft 账号的角色皮肤文件",
 	"Types": ["启动器"]

--- a/启动器/角色皮肤导出.xaml
+++ b/启动器/角色皮肤导出.xaml
@@ -1,12 +1,5 @@
 <local:MyHint Margin="0,0,0,15" Text="该帮助页面还需要根据规范重新整理格式，优化排版与文案。如果你感兴趣也可以来帮帮忙！" IsWarn="False" />
 
-<local:MyCard Title="导出角色皮肤">
-    <StackPanel Margin="25,40,23,0">
-        <TextBlock Margin="0,0,0,4" LineHeight="17"
-                   Text="PCL2 的皮肤加载渠道分为以下三种：&#xa;1. 登录验证获取皮肤；&#xa;2. 直接加载正版用户的皮肤；&#xa;3. 本地加载。&#xa;" />
-    </StackPanel>
-</local:MyCard>
-
 <local:MyCard Title="正版登录">
     <StackPanel Margin="25,40,23,15">
         <Grid>
@@ -30,10 +23,6 @@
 
 <local:MyCard Title="离线及第三方登录">
     <StackPanel Margin="25,40,23,15">
-        <TextBlock Margin="0,0,0,4" LineHeight="17"
-                   Text="对于第三方登录用户，请先确认登录配置正确。你可以参考以下帮助文档。" />
-        <local:MyListItem Margin="0,0,0,12"
-		   EventType="打开帮助" EventData="启动器/指定登录方式.json" />
         <Grid>
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
                         Text="1. 进入启动页面，右键点击角色头像，选择 “另存为”。" HorizontalAlignment="Left" />

--- a/启动器/角色皮肤导出.xaml
+++ b/启动器/角色皮肤导出.xaml
@@ -1,24 +1,50 @@
 <local:MyHint Margin="0,0,0,15" Text="该帮助页面还需要根据规范重新整理格式，优化排版与文案。如果你感兴趣也可以来帮帮忙！" IsWarn="False" />
 
 <local:MyCard Title="导出角色皮肤">
-    <StackPanel Margin="25,40,23,15">
+    <StackPanel Margin="25,40,23,0">
         <TextBlock Margin="0,0,0,4" LineHeight="17"
-                   Text="PCL2 的皮肤加载渠道分为以下三种：&#xa;1. 登录验证获取皮肤；&#xa;2. 直接加载正版用户的皮肤；&#xa;3. 本地加载。&#xa;本教程的导出方法适用于前两种情况。" />
+                   Text="PCL2 的皮肤加载渠道分为以下三种：&#xa;1. 登录验证获取皮肤；&#xa;2. 直接加载正版用户的皮肤；&#xa;3. 本地加载。&#xa;" />
     </StackPanel>
 </local:MyCard>
 
-<local:MyCard Title="教程">
+<local:MyCard Title="正版登录">
+    <StackPanel Margin="25,40,23,15">
+        <Grid>
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
+                        Text="1. 进入启动页面，将鼠标悬浮于角色头像附近，此时下方会出现三个选项图标。" HorizontalAlignment="Left" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2023/06/03/647aa0e1c0320.png?comment=正版登录选项" />
+        </Grid>
+
+        <Grid>
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
+                        Text="2. 点击 “皮肤与披风” 选项，选择 “保存皮肤”。" HorizontalAlignment="Left" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2023/06/03/647aa228e5fe1.png?comment=正版登录导出" />
+        </Grid>
+
+        <Grid Margin="0,20,0,4">
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4"
+                        Text="3. 在弹出的对话框中选择导出路径，即可将皮肤文件导出。"/>
+        </Grid>
+    </StackPanel>
+</local:MyCard>
+
+<local:MyCard Title="离线及第三方登录">
     <StackPanel Margin="25,40,23,15">
         <TextBlock Margin="0,0,0,4" LineHeight="17"
-                   Text="对于第三方登录用户，请先确认登录配置正确。&#xa;你可以参考以下帮助文档。" />
-        <local:MyListItem Margin="0,0,0,0"
+                   Text="对于第三方登录用户，请先确认登录配置正确。你可以参考以下帮助文档。" />
+        <local:MyListItem Margin="0,0,0,12"
 		   EventType="打开帮助" EventData="启动器/指定登录方式.json" />
-        <TextBlock Margin="0,0,0,4" LineHeight="17"
-                   Text="1. 进入启动页面，右键点击角色头像。" />
-        <Image HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/10/1/9IKCYT5HUWa43Me.png" />     
-        <TextBlock Margin="0,0,0,4" LineHeight="17"
-                   Text="2. 在弹出的对话框中选择导出路径，即可将皮肤文件导出。" />
+        <Grid>
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
+                        Text="1. 进入启动页面，右键点击角色头像，选择 “另存为”。" HorizontalAlignment="Left" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2023/06/03/647a9f8c272e6.png?comment=第三方登录导出皮肤" />
+        </Grid>
+
+        <Grid Margin="0,20,0,4">
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4"
+                        Text="2. 在弹出的对话框中选择导出路径，即可将皮肤文件导出。"/>
+        </Grid>
     </StackPanel>
 </local:MyCard>
 
-<local:MyHint Margin="0,0,0,15" Text="作者：DreamUniverse" IsWarn="False" />
+<local:MyHint Margin="0,0,0,15" Text="作者：DreamUniverse、风释清然SC" IsWarn="False" />


### PR DESCRIPTION
## 前言
原帮助页面有部分内容已过期，在此对其进行增添、优化、修改以适配 PCL 2.6.0+ 🥳

## 内容
- 由于离线皮肤也可以导出，因此删除了 “本教程的导出方法适用于前两种情况。” 的表述
- 添加导出正版皮肤步骤
- 更换第三方登录导出皮肤图片，使图片中启动器主题为龙猫蓝
- 补充部分遗漏的表述
- 统一教程步骤排版格式及细节优化