### PR TITLE
优化 数据包安装 资源包安装 页面

### DIFF
--- a/Minecraft/数据包安装.xaml
+++ b/Minecraft/数据包安装.xaml
@@ -80,7 +80,7 @@
                         Text="1. 参考上方内容启动您想要安装数据包的版本，点击“单人游戏”。" HorizontalAlignment="Left" />
             <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/10/1/World-List.png" />        
         </Grid>
-        <local:MyHint Margin="0,15,0,0" Text="如果你还没有创建任何世界则无需点击“创建新的世界”按钮，则直接点击右中“数据包”。" IsWarn="False" />
+        <local:MyHint Margin="0,15,0,0" Text="如果你还没有创建任何世界则无需点击“创建新的世界”按钮，则直接点击右中“数据包”。&#xa;对于 1.20 及以上版本，你需要在创建世界页面上方单击 “更多” 选项卡以找到 “数据包” 按钮。" IsWarn="False" />
         <Grid Margin="0,20,0,4">
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
                         Text="2. 点击下方“创建新的世界”，点击右中“数据包”" HorizontalAlignment="Left" />

--- a/Minecraft/资源包安装.xaml
+++ b/Minecraft/资源包安装.xaml
@@ -17,7 +17,7 @@
     </StackPanel>
 </local:MyCard>
 
-<local:MyCard Title="通用方法" Margin="0,0,0,15">
+<local:MyCard Title="导入纹理包（材质包）" Margin="0,0,0,15">
     <StackPanel Margin="25,40,23,15">
         <Grid>
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
@@ -69,7 +69,7 @@
         </Grid>
 
         <TextBlock TextWrapping="Wrap" Margin="0,15,0,4"
-                   Text="3. 最后，等待红色 Mojang 进度条至尽头，资源包就已加载完成。"/>
+                   Text="3. 最后，等待 Mojang 进度条至尽头，资源包就已加载完成。"/>
     </StackPanel>
 </local:MyCard>
 


### PR DESCRIPTION
## 前言
本 Pr 针对上述两页面进行了表述修正与细节修正。可能有些较真，但毕竟严谨点更好点啦……qwq

## 内容
### Minecraft/数据包安装.xaml
- 由于 1.20 创建世界页面发生较大改动，因此在 “加载数据包” 段落添加相应表述以使教程合乎新版本内容。

### Minecraft/资源包安装.xaml
- 修改段落名 “通用方法” -> “导入纹理包（材质包）”，因为该段落并未讲述如何启用资源包，而只是描述了如何将资源包导入文件夹这一步骤，原名称并不严谨。
- 修改表述 “等待红色 Mojang 进度条至尽头” -> “等待 Mojang 进度条至尽头”，因为在较高版本中的辅助功能设置中可以修改徽标颜色为黑色。