### PR TITLE
添加 将排除项添加到 Windows 安全中心 帮助页面

### DIFF
--- a/启动器/Microsoft Defender 添加排除项.json
+++ b/启动器/Microsoft Defender 添加排除项.json
@@ -3,5 +3,5 @@
     "Title": "将 PCL2 添加到 Windows 安全中心白名单",
     "Description": "PCL2 被静默删除时可能的解决方案",
     "Types": ["启动器"],
-	"ShowInPublic": false
+    "ShowInPublic": false
 }

--- a/启动器/Microsoft Defender 添加排除项.json
+++ b/启动器/Microsoft Defender 添加排除项.json
@@ -1,6 +1,7 @@
 {
     "__Author__": "风释清然SC",
-    "Title": "将排除项添加到 Windows 安全中心",
+    "Title": "将 PCL2 添加到 Windows 安全中心白名单",
     "Description": "PCL2 被静默删除时可能的解决方案",
-    "Types": ["启动器"]
+    "Types": ["启动器"],
+	"ShowInPublic": false
 }

--- a/启动器/Microsoft Defender 添加排除项.json
+++ b/启动器/Microsoft Defender 添加排除项.json
@@ -1,0 +1,6 @@
+{
+    "__Author__": "风释清然SC",
+    "Title": "将排除项添加到 Windows 安全中心",
+    "Description": "PCL2 被静默删除时可能的解决方案",
+    "Types": ["启动器"]
+}

--- a/启动器/Microsoft Defender 添加排除项.xaml
+++ b/启动器/Microsoft Defender 添加排除项.xaml
@@ -1,6 +1,6 @@
 <local:MyHint Margin="0,0,0,15" Text="该帮助页面还需要进一步完善，优化排版与文案。如果您感兴趣也可以来帮帮忙！" IsWarn="False" />
 
-<local:MyCard Title="概述：为什么会被静默删除？">
+<local:MyCard Title="PCL2 为什么会被静默删除？">
     <StackPanel Margin="25,40,23,15">
         <TextBlock Margin="0,0,0,4" LineHeight="19"
                    Text="您现在正在使用快照版 PCL2，由于快照版版本未向 Microsoft 提交误报反馈，因此 PCL2 快照版可能被 Microsoft Defender 在不做任何提醒的情况下静默删除。" />

--- a/启动器/Microsoft Defender 添加排除项.xaml
+++ b/启动器/Microsoft Defender 添加排除项.xaml
@@ -1,0 +1,74 @@
+<local:MyHint Margin="0,0,0,15" Text="该帮助页面还需要进一步完善，优化排版与文案。如果您感兴趣也可以来帮帮忙！" IsWarn="False" />
+
+<local:MyCard Title="概述：为什么会被静默删除？">
+    <StackPanel Margin="25,40,23,15">
+        <TextBlock Margin="0,0,0,4" LineHeight="19"
+                   Text="您现在正在使用快照版 PCL2，由于快照版版本未向 Microsoft 提交误报反馈，因此 PCL2 快照版可能被 Microsoft Defender 在不做任何提醒的情况下静默删除。" />
+    </StackPanel>
+</local:MyCard>
+
+<local:MyCard Title="Windows 10" Margin="0,0,0,15" CanSwap="True" IsSwaped="True">
+	<StackPanel Margin="25,40,23,15">
+        <Grid>
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
+                       Text="1. 在开始菜单中打开设置，选择 “更新与安全”。" HorizontalAlignment="Left" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2023/06/29/649d8e552c862.png" />
+        </Grid>
+
+        <Grid Margin="0,20,0,4">
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
+                       Text="2. 进入左侧菜单中的 “Windows 安全中心” 选项，单击右侧的 “打开 Windows 安全中心” 按钮。" HorizontalAlignment="Left" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2023/06/29/649d8f71c75ae.png" />
+        </Grid>
+
+        <local:MyHint Margin="0,20,0,0" Text="若打开 Windows 安全中心后未找到 “病毒和威胁防护” 字样，请直接选择左侧菜单栏中有盾牌图标的选项即可。" IsWarn="False" />
+        <Grid Margin="0,10,0,0">
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
+                       Text="3. 在弹出的 Windows 安全中心窗口中的左侧菜单栏中选择 “病毒和威胁防护”，在弹出的页面中向下滚动页面，找到并进入 “管理设置”。" HorizontalAlignment="Left" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2023/06/29/649d8fe859c58.png" />
+        </Grid>
+
+        <Grid Margin="0,20,0,4">
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
+                       Text="4. 在出现的 “‘病毒和威胁防护’ 设置” 中向下滚动页面，找到并进入 “添加或删除排除项”。" HorizontalAlignment="Left" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2023/06/29/649d91bda42d4.png" />
+        </Grid>
+
+        <Grid Margin="0,20,0,4">
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
+                       Text="5. 在出现的 “排除项” 页面中点击 “添加排除项” 按钮，选择 “文件夹”，选择 PCL2 所在的文件夹，点击 “确定”。" HorizontalAlignment="Left" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2023/06/29/649d937ed6a50.png" />
+        </Grid>
+    </StackPanel>
+</local:MyCard>
+
+<local:MyCard Title="Windows 11" Margin="0,0,0,15" CanSwap="True" IsSwaped="True">
+	<StackPanel Margin="25,40,23,15">
+        <Grid>
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
+                       Text="1. 在开始菜单中打开设置，选择左侧菜单中的 “隐私和安全性”，单击右侧 “Windows 安全中心” 选项。" HorizontalAlignment="Left" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2023/06/29/649d948165b24.png" />
+        </Grid>
+
+        <local:MyHint Margin="0,20,0,0" Text="若打开 Windows 安全中心后未找到 “病毒和威胁防护” 字样，请直接选择左侧菜单栏中有盾牌图标的选项即可。" IsWarn="False" />
+        <Grid Margin="0,10,0,0">
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
+                       Text="2. 在弹出的 Windows 安全中心窗口中的左侧菜单栏中选择 “病毒和威胁防护”，在弹出的页面中向下滚动页面，找到并进入 “管理设置”。" HorizontalAlignment="Left" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2023/06/29/649d8fe859c58.png" />
+        </Grid>
+
+        <Grid Margin="0,20,0,4">
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
+                       Text="3. 在出现的 “‘病毒和威胁防护’ 设置” 中向下滚动页面，找到并进入 “添加或删除排除项”。" HorizontalAlignment="Left" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2023/06/29/649d91bda42d4.png" />
+        </Grid>
+
+        <Grid Margin="0,20,0,4">
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
+                       Text="4. 在出现的 “排除项” 页面中点击 “添加排除项” 按钮，选择 “文件夹”，选择 PCL2 所在的文件夹，点击 “确定”。" HorizontalAlignment="Left" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2023/06/29/649d937ed6a50.png" />
+        </Grid>
+    </StackPanel>
+</local:MyCard>
+
+<local:MyHint Margin="0,0,0,15" Text="作者：风释清然SC" IsWarn="False" />

--- a/启动器/Microsoft Defender 添加排除项.xaml
+++ b/启动器/Microsoft Defender 添加排除项.xaml
@@ -1,9 +1,9 @@
-<local:MyHint Margin="0,0,0,15" Text="该帮助页面还需要进一步完善，优化排版与文案。如果您感兴趣也可以来帮帮忙！" IsWarn="False" />
+<!--图片备份：https://github.com/WForst-Breeze/Files/tree/main/PCL2/Help_image3 -->
 
 <local:MyCard Title="PCL2 为什么会被静默删除？">
     <StackPanel Margin="25,40,23,15">
         <TextBlock Margin="0,0,0,4" LineHeight="19"
-                   Text="您现在正在使用快照版 PCL2，由于快照版版本未向 Microsoft 提交误报反馈，因此 PCL2 快照版可能被 Microsoft Defender 在不做任何提醒的情况下静默删除。" />
+                   Text="由于 PCL2 会联网下载程序并且运行，经常被杀毒软件和 Microsoft Defender 误判为病毒，这是正常现象。如遇到报毒等情况，也可以尝试参考本教程进行处理。&#xA;您现在正在使用快照版 PCL2，由于未向 Microsoft 提交误报反馈，因此 PCL2 快照版可能被 Microsoft Defender 在不做任何提醒的情况下静默删除。" />
     </StackPanel>
 </local:MyCard>
 

--- a/启动器/Microsoft Defender 添加排除项.xaml
+++ b/启动器/Microsoft Defender 添加排除项.xaml
@@ -18,7 +18,7 @@
         <Grid Margin="0,20,0,4">
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
                        Text="2. 进入左侧菜单中的 “Windows 安全中心” 选项，单击右侧的 “打开 Windows 安全中心” 按钮。" HorizontalAlignment="Left" />
-            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2023/06/29/649d8f71c75ae.png" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2023/06/29/649d962150f5d.png" />
         </Grid>
 
         <local:MyHint Margin="0,20,0,0" Text="若打开 Windows 安全中心后未找到 “病毒和威胁防护” 字样，请直接选择左侧菜单栏中有盾牌图标的选项即可。" IsWarn="False" />
@@ -37,7 +37,7 @@
         <Grid Margin="0,20,0,4">
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
                        Text="5. 在出现的 “排除项” 页面中点击 “添加排除项” 按钮，选择 “文件夹”，选择 PCL2 所在的文件夹，点击 “确定”。" HorizontalAlignment="Left" />
-            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2023/06/29/649d937ed6a50.png" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2023/06/29/649d963b7c37a.png" />
         </Grid>
     </StackPanel>
 </local:MyCard>
@@ -66,7 +66,7 @@
         <Grid Margin="0,20,0,4">
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
                        Text="4. 在出现的 “排除项” 页面中点击 “添加排除项” 按钮，选择 “文件夹”，选择 PCL2 所在的文件夹，点击 “确定”。" HorizontalAlignment="Left" />
-            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2023/06/29/649d937ed6a50.png" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2023/06/29/649d963b7c37a.png" />
         </Grid>
     </StackPanel>
 </local:MyCard>


### PR DESCRIPTION
## 前言
该帮助文档添加了 将排除项添加到 Windows 安全中心 相关教程，微软官方给出的教程中大部分操作已经过时了，因此在此处添加该帮助文档以尽可能使得用户可以快捷地完成排除项添加。

### 备注
因为我不太清楚是不是在文件名后添加 “ - Snapshot” 就可以仅快照版显示了，也不确定是否有必要仅快照版显示（#305），因此这里我暂时没有进行相关改动。如果有必要仅快照版显示，我就改改文件名，如果没必要的话我就修改一下第一个 MyCard 的表述。谢谢qwq！

图片尽可能做到清晰舒服了，难免会有一些问题，还请多多包容啦~

###### ~Win 11 部分偷了个懒，只更换了设置界面的图片，但不影响实际情况下的操作~