### PR TITLE
修改部分 PCL 字样为 PCL2 及其他细节优化

### DIFF
--- a/帮助/提交帮助 - GitHub Desktop.xaml
+++ b/帮助/提交帮助 - GitHub Desktop.xaml
@@ -13,16 +13,16 @@
                         Text="打开文件夹" EventType="打开文件" EventData="explorer.exe|/select,Help" />
         </StackPanel>        
         <TextBlock Margin="0,0,0,4" LineHeight="17"
-                    Text="打开你 Clone 的仓库的本地文件夹，在文件浏览器中，开启“显示隐藏的项目”选项以选中 .git 文件夹。&#xa;此后，将整个 PCLHelp 内的内容剪切到 PCL/Help 文件夹下。"/>
+                    Text="打开你 Clone 的仓库的本地文件夹，在文件浏览器中，开启 “显示隐藏的项目” 选项以选中 .git 文件夹。&#xa;此后，将整个 PCL2Help 内的内容剪切到 PCL/Help 文件夹下。"/>
         <local:MyHint Margin="0,0,0,15" Text="在剪切后 .git 文件夹必须位于 PCL\Help，而不能在 PCL\Help\PCL2Help 子文件夹中" />
         <TextBlock Margin="0,0,0,4" LineHeight="17"
                     Text="使用你喜爱的编辑器编辑文件，并保存。"/>
         <TextBlock Margin="0,0,0,4" LineHeight="17"
-                    Text="在 GitHub Desktop 仓库界面左侧栏，找到你修改的文件，并在文件左侧的方框中选中(仅选中一个文件，如要选中多个文件，请在 Commit to main 按钮上方的文本框输入消息)。&#xa;在右侧的文件预览中确认无误后，单击“Commit to main”(位于左侧栏的下方) "/>
+                    Text="在 GitHub Desktop 仓库界面左侧栏，找到你修改的文件，并在文件左侧的方框中选中(仅选中一个文件，如要选中多个文件，请在 Commit to main 按钮上方的文本框输入消息)。&#xa;在右侧的文件预览中确认无误后，单击 “Commit to main” (位于左侧栏的下方) "/>
         <TextBlock Margin="0,0,0,4" LineHeight="17"
-                    Text="在所有文件均提交完毕后，按下“Ctrl+P”以推送至 GitHub。"/>
+                    Text="在所有文件均提交完毕后，按下 “Ctrl+P” 以推送至 GitHub。"/>
         <TextBlock Margin="0,0,0,4" LineHeight="17"
-                    Text="在窗口标题栏下方，选中“Current branch”,再在子栏底部选择“Choose a branch to merge into master”以新建拉取请求。&#xa;选中 master 分支，并单击子窗口下方的蓝色按钮确认。"/>
+                    Text="在窗口标题栏下方，选中 “Current branch”,再在子栏底部选择 “Choose a branch to merge into master” 以新建拉取请求。&#xa;选中 master 分支，并单击子窗口下方的蓝色按钮确认。"/>
     </StackPanel>
 </local:MyCard>
 

--- a/帮助/提交帮助 - VSCode.xaml
+++ b/帮助/提交帮助 - VSCode.xaml
@@ -21,7 +21,7 @@
 <local:MyCard Title="使用 VSCode 获取帮助库并提交">
     <StackPanel Margin="25,40,23,15">
         <TextBlock Margin="0,0,0,4" LineHeight="17"
-                    Text="1. 即使你使用 VSCode 依旧需要安装 Git 工具。点击左侧的第三个按钮&quot;源代码管理&quot;，按照 VSCode 的引导完成 Git 安装。"/>
+                    Text="1. 即使你使用 VSCode 依旧需要安装 Git 工具。点击左侧的第三个按钮 &quot;源代码管理&quot; ，按照 VSCode 的引导完成 Git 安装。"/>
         <Image HorizontalAlignment="Center" Source="https://cdn.newfei.top/image/2023/01/13/ouXw.jpg" />
         <TextBlock Margin="0,0,0,4" LineHeight="17"
                     Text="2. 在左下角管理 → 设置或按下键盘上的 Ctrl 键 + , 键，在搜索框中输入 “git.path”，点击 “在 settings.json 中” 并设置 git.exe 路径（&lt;Git 安装路径&gt;\bin\git.exe），然后保存（Ctrl + S）" />
@@ -42,15 +42,15 @@
                         Text="打开文件夹" EventType="打开文件" EventData="explorer.exe|/select,Help" />
         </StackPanel>
         <TextBlock Margin="0,0,0,15" LineHeight="17"
-                    Text="完成上述后，将第二步 clone 下仓库内 PCLHelp 文件夹中的内容剪切到 PCL\Help 中。在资源管理器中，在查看 → 显示下方选中&quot;隐藏的项目&quot;并将该文件夹内所有文件剪切至 PCL\Help 文件夹。"/>
+                    Text="完成上述后，将第二步 clone 下仓库内 PCL2Help 文件夹中的内容剪切到 PCL\Help 中。在资源管理器中，在查看 → 显示下方选中 &quot;隐藏的项目&quot; 并将该文件夹内所有文件剪切至 PCL\Help 文件夹。"/>
         <local:MyHint Margin="0,0,0,4" Text="在剪切后 .git 文件夹必须位于 PCL\Help，而不能在 PCL\Help\PCL2Help 中" />
         <TextBlock Margin="0,10,0,4" LineHeight="17"
                     Text="最后，点击左边栏 → 源代码管理 → 打开文件夹，选择 Help 文件夹即可。"/>
         <TextBlock Margin="0,0,0,4" LineHeight="17"
-                    Text="在获取帮助库后，你就可以按照正常自定义帮助的方式对帮助库进行修改了。修改完成后，点击左侧的第三个按钮&quot;源代码管理&quot;或按下键盘上的 Ctrl 键 + Shit 键 + G 键，在上方输入你的修改内容，点击&quot;更改&quot;旁边的 + 号，再点击&quot;源代码管理&quot;旁边的 + 号，将你的更新暂存，再点击下方的&quot;master&quot;旁边的按钮，你的更新就被推送到你的 Fork 仓库了。"/>
+                    Text="在获取帮助库后，你就可以按照正常自定义帮助的方式对帮助库进行修改了。修改完成后，点击左侧的第三个按钮 &quot;源代码管理&quot; 或按下键盘上的 Ctrl 键 + Shit 键 + G 键，在上方输入你的修改内容，点击 &quot;更改&quot; 旁边的 + 号，再点击 &quot;源代码管理&quot; 旁边的 + 号，将你的更新暂存，再点击下方的 &quot;master&quot; 旁边的按钮，你的更新就被推送到你的 Fork 仓库了。"/>
         <Image HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/10/1/VSCode.Pull.Changes.png" />
         <TextBlock Margin="0,0,0,4" LineHeight="17"
-                    Text="在 Pull Request 前，你需要同步原仓库内的内容以保证你的仓库保持最新。打开你的 Fork 仓库主页，找到&quot;Fetch upstream (从上游获取)&quot;按钮并点击，再点击&quot;Fetch and merge (获取并合并)&quot;，你的仓库就同步了原仓库。经过了这些步骤之后，你就可以提交你的 Pull Request 了。"/>
+                    Text="在 Pull Request 前，你需要同步原仓库内的内容以保证你的仓库保持最新。打开你的 Fork 仓库主页，找到 &quot;Fetch upstream (从上游获取)&quot; 按钮并点击，再点击 &quot;Fetch and merge (获取并合并)&quot;，你的仓库就同步了原仓库。经过了这些步骤之后，你就可以提交你的 Pull Request 了。"/>
         <Image HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/10/1/Github.Fetch.upstream.png" />
     </StackPanel>
 </local:MyCard>

--- a/帮助/提交帮助 - VSCode.xaml
+++ b/帮助/提交帮助 - VSCode.xaml
@@ -21,7 +21,7 @@
 <local:MyCard Title="使用 VSCode 获取帮助库并提交">
     <StackPanel Margin="25,40,23,15">
         <TextBlock Margin="0,0,0,4" LineHeight="17"
-                    Text="1. 即使你使用 VSCode 依旧需要安装 Git 工具。点击左侧的第三个按钮 &quot;源代码管理&quot; ，按照 VSCode 的引导完成 Git 安装。"/>
+                    Text="1. 即使你使用 VSCode 依旧需要安装 Git 工具。点击左侧的第三个按钮 &quot;源代码管理&quot;，按照 VSCode 的引导完成 Git 安装。"/>
         <Image HorizontalAlignment="Center" Source="https://cdn.newfei.top/image/2023/01/13/ouXw.jpg" />
         <TextBlock Margin="0,0,0,4" LineHeight="17"
                     Text="2. 在左下角管理 → 设置或按下键盘上的 Ctrl 键 + , 键，在搜索框中输入 “git.path”，点击 “在 settings.json 中” 并设置 git.exe 路径（&lt;Git 安装路径&gt;\bin\git.exe），然后保存（Ctrl + S）" />

--- a/帮助/提交帮助 - 编写规范.xaml
+++ b/帮助/提交帮助 - 编写规范.xaml
@@ -43,7 +43,7 @@
         <TextBlock Foreground="#229922" Margin="0,0,0,10"
                     Text="    ✔  要修改 PCL 的内置帮助库，在提交 Pull Request 后还需要等待审核。" />
         <TextBlock Margin="0,0,0,2"
-                    Text="3. 注意大小写。在中文与非中文的连接处添加一个空格（双引号除外）。使用中文标点符号（例如括号）。" />
+                    Text="3. 注意大小写。在中文与非中文的连接处、引号与引号外文字的连接处添加一个空格（双引号除外）。使用中文标点符号（例如括号）。" />
         <TextBlock Margin="0,0,0,4"
                     Text="4. 使用 PCL、Minecraft、Mojang 作为标准称谓。不要使用 我的世界、MC、mj 等非标准称谓或缩写。" />
         <TextBlock Foreground="#DD4411" Margin="0,0,0,2"


### PR DESCRIPTION
## 修改内容
- 将部分 PCL 字样改回 PCL2，因为这是本仓库的名称：PCL2Help 而非 PCLHelp
- 该页面引号前后补添空格
- 编写规范中添加引号前后添加空格要求