### PR TITLE
修正标点符号问题

### DIFF
--- a/Minecraft/存档损坏.xaml
+++ b/Minecraft/存档损坏.xaml
@@ -11,7 +11,7 @@
                     Text="3. 找到 “level.dat_old”，并右键重命名，将后缀 “_old” 部分删除。 "/>
         <TextBlock TextWrapping="Wrap" Margin="0,0,0,4" LineHeight="17"
                     Text="此时进入游戏将恢复存档，但注意的是：每次进入游戏都会自动备份存档为 level.dat_old 文件，所以使用此文档会回档到未损坏之前的存档 。"/>
-        <local:MyHint Text="如果没有显示后缀，请将显示文件扩展名打开即可 &#xA; Win7：资源管理器(我的电脑) → 组织 → 文件夹和搜索选项 → 查看 → 勾选“显示已知文件的扩展名” &#xA; Win10、Win11：资源管理器(此电脑) → 查看 → 勾选 “文件扩展名” " IsWarn="False" />
+        <local:MyHint Text="如果没有显示后缀，请将显示文件扩展名打开即可 &#xA; Win7：资源管理器（我的电脑） → 组织 → 文件夹和搜索选项 → 查看 → 勾选 “显示已知文件的扩展名” &#xA; Win10、Win11：资源管理器（此电脑） → 查看 → 勾选 “文件扩展名” " IsWarn="False" />
     </StackPanel>
 </local:MyCard>
 <local:MyHint Margin="0,0,0,15" Text="作者：XiaoFans" IsWarn="False" />

--- a/Minecraft/存档损坏.xaml
+++ b/Minecraft/存档损坏.xaml
@@ -4,14 +4,14 @@
         <TextBlock TextWrapping="Wrap" Margin="0,0,0,4" LineHeight="17"
                     Text="电脑蓝屏、死机重启等情况下，游戏存档可能会损坏，如果损坏请按照以下步骤操作："/>
         <TextBlock TextWrapping="Wrap" Margin="0,0,0,4" LineHeight="17"
-                    Text="1. 点击对应版本的“版本设置” → “存档文件夹”后打开 saves 文件夹。"/>
+                    Text="1. 点击对应版本的 “版本设置” → “存档文件夹” 后打开 saves 文件夹。"/>
         <TextBlock TextWrapping="Wrap" Margin="0,0,0,4" LineHeight="17"
-                    Text="2. 进入损坏存档，删除“level.dat”文件。"/>
+                    Text="2. 进入损坏存档，删除 “level.dat” 文件。"/>
         <TextBlock TextWrapping="Wrap" Margin="0,0,0,4" LineHeight="17"
-                    Text="3. 找到“level.dat_old”，并右键重命名，将后缀 “_old” 部分删除。 "/>
+                    Text="3. 找到 “level.dat_old”，并右键重命名，将后缀 “_old” 部分删除。 "/>
         <TextBlock TextWrapping="Wrap" Margin="0,0,0,4" LineHeight="17"
                     Text="此时进入游戏将恢复存档，但注意的是：每次进入游戏都会自动备份存档为 level.dat_old 文件，所以使用此文档会回档到未损坏之前的存档 。"/>
-        <local:MyHint Text="如果没有显示后缀，请将显示文件扩展名打开即可 &#xA; Win7：资源管理器(我的电脑) → 组织 → 文件夹和搜索选项 → 查看 → 勾选“显示已知文件的扩展名” &#xA; Win10、Win11：资源管理器(此电脑) → 查看 → 勾选“文件扩展名” " IsWarn="False" />
+        <local:MyHint Text="如果没有显示后缀，请将显示文件扩展名打开即可 &#xA; Win7：资源管理器(我的电脑) → 组织 → 文件夹和搜索选项 → 查看 → 勾选“显示已知文件的扩展名” &#xA; Win10、Win11：资源管理器(此电脑) → 查看 → 勾选 “文件扩展名” " IsWarn="False" />
     </StackPanel>
 </local:MyCard>
 <local:MyHint Margin="0,0,0,15" Text="作者：XiaoFans" IsWarn="False" />

--- a/Minecraft/安装世界.xaml
+++ b/Minecraft/安装世界.xaml
@@ -22,21 +22,21 @@
 		<TextBlock TextWrapping="Wrap" Margin="0,0,0,4"
                    Text="世界下载完成后需要导入方可在游戏中使用。导入世界只需将您得到的地图文件夹放入 .minecraft/saves 文件夹即可。" />
 		<local:MyHint Margin="0,0,0,15" Text="如果你开启了版本隔离，路径应该是.minecraft/versions/你的版本名/saves" IsWarn="False" />
-		<TextBlock TextWrapping="Wrap" Margin="0,0,0,4" LineHeight="17" Text="有些地图的文件夹根目录有 resources.zip 文件，这是地图自带的纹理包（材质包），您可以参考“安装资源包”教程进行安装。"/>
+		<TextBlock TextWrapping="Wrap" Margin="0,0,0,4" LineHeight="17" Text="有些地图的文件夹根目录有 resources.zip 文件，这是地图自带的纹理包（材质包），您可以参考 “安装资源包”教程进行安装。"/>
 		<local:MyListItem Margin="-5,0,-5,8"
 		                  EventType="打开帮助" EventData="Minecraft/资源包安装.json" />
 		<Image HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/10/1/explorer-saves-folder.png" />
 		<Image HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/10/1/explorer-import-worlds.png" />
 		<local:MyHint Margin="0,0,0,15" Text="注意: 大部分地图下载下来后为压缩文件(.rar / .zip / .7z)，您需要解压后放入 saves 文件夹。" IsWarn="False"/>
 		<TextBlock TextWrapping="Wrap" Margin="0,0,0,4"
-                    Text="如果您开启了版本隔离，则您需要在 PCL 中选中您需要安装世界的版本，点击右侧的小齿轮(或在主页点击“版本设置”)，然后点击“打开版本文件夹”，找到 .minecraft/saves 文件夹再将世界放入此文件夹。"/>
+                    Text="如果您开启了版本隔离，则您需要在 PCL 中选中您需要安装世界的版本，点击右侧的小齿轮(或在主页点击“版本设置”)，然后点击 “打开版本文件夹”，找到 .minecraft/saves 文件夹再将世界放入此文件夹。"/>
 		<Image HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/26/6/click_example_choose.png"/>
 		<Image HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/26/6/click_settings.png"/>
 		<Image HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/26/6/open_version_folder.png"/>
 		<Image HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/26/6/explorer-saves-folder.png"/>
 		<Image HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/26/6/explorer-other-saves.png"/>
 		<TextBlock TextWrapping="Wrap" Margin="0,0,0,4"
-                    Text="在 PCL 中选中您刚才导入世界的版本，点击启动，点击“单人游戏”，找到您刚刚导入的存档(一般与文件夹同名)，双击以游玩。"/>
+                    Text="在 PCL 中选中您刚才导入世界的版本，点击启动，点击 “单人游戏”，找到您刚刚导入的存档(一般与文件夹同名)，双击以游玩。"/>
 		<Image HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/26/6/minecraft-play.png"/>
 	</StackPanel>
 </local:MyCard>

--- a/Minecraft/安装世界.xaml
+++ b/Minecraft/安装世界.xaml
@@ -6,13 +6,13 @@
 		<TextBlock TextWrapping="Wrap" Margin="0,0,0,4"
                    Text="世界 (Worlds, 亦称为地图、存档) 是指由 Minecraft 玩家创造的存档。玩家的游戏中生成的世界可以被其他玩家下载并进行游玩。" />
 		<TextBlock TextWrapping="Wrap" Margin="0,0,0,4"
-                    Text="目前国内外比较知名的世界分享网站有 MCBBS(我的世界中文论坛) 和 MinecraftMaps 等。"/>
+                    Text="目前国内外比较知名的世界分享网站有 MCBBS（我的世界中文论坛）和 MinecraftMaps 等。"/>
 	</StackPanel>
 </local:MyCard>
 <local:MyCard Title="获取世界" Margin="0,0,0,15">
 	<StackPanel Margin="25,40,23,15">
 		<TextBlock TextWrapping="Wrap" Margin="0,0,0,4"
-                   Text="世界与纹理包（材质包）、光影类似，是由 Minecraft 玩家创作并分享的，你可以在网上找到其他玩家制作的世界。很多 Minecraft 交流网站(如 MCBBS)都有专门的世界版块，你可以在这些地方挑选自己喜欢的世界。" />
+                   Text="世界与纹理包（材质包）、光影类似，是由 Minecraft 玩家创作并分享的，你可以在网上找到其他玩家制作的世界。很多 Minecraft 交流网站（如 MCBBS）都有专门的世界版块，你可以在这些地方挑选自己喜欢的世界。" />
 		<local:MyButton Height="35" HorizontalAlignment="Left" Padding="13,0,13,0"
                    Text="打开 MCBBS 世界分享板块" EventType="打开网页" EventData="https://www.mcbbs.net/forum-map-1.html" />
 	</StackPanel>
@@ -27,16 +27,16 @@
 		                  EventType="打开帮助" EventData="Minecraft/资源包安装.json" />
 		<Image HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/10/1/explorer-saves-folder.png" />
 		<Image HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/10/1/explorer-import-worlds.png" />
-		<local:MyHint Margin="0,0,0,15" Text="注意: 大部分地图下载下来后为压缩文件(.rar / .zip / .7z)，您需要解压后放入 saves 文件夹。" IsWarn="False"/>
+		<local:MyHint Margin="0,0,0,15" Text="注意: 大部分地图下载下来后为压缩文件（.rar / .zip / .7z），您需要解压后放入 saves 文件夹。" IsWarn="False"/>
 		<TextBlock TextWrapping="Wrap" Margin="0,0,0,4"
-                    Text="如果您开启了版本隔离，则您需要在 PCL 中选中您需要安装世界的版本，点击右侧的小齿轮(或在主页点击“版本设置”)，然后点击 “打开版本文件夹”，找到 .minecraft/saves 文件夹再将世界放入此文件夹。"/>
+                    Text="如果您开启了版本隔离，则您需要在 PCL 中选中您需要安装世界的版本，点击右侧的小齿轮（或在主页点击 “版本设置”），然后点击 “打开版本文件夹”，找到 .minecraft/saves 文件夹再将世界放入此文件夹。"/>
 		<Image HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/26/6/click_example_choose.png"/>
 		<Image HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/26/6/click_settings.png"/>
 		<Image HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/26/6/open_version_folder.png"/>
 		<Image HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/26/6/explorer-saves-folder.png"/>
 		<Image HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/26/6/explorer-other-saves.png"/>
 		<TextBlock TextWrapping="Wrap" Margin="0,0,0,4"
-                    Text="在 PCL 中选中您刚才导入世界的版本，点击启动，点击 “单人游戏”，找到您刚刚导入的存档(一般与文件夹同名)，双击以游玩。"/>
+                    Text="在 PCL 中选中您刚才导入世界的版本，点击启动，点击 “单人游戏”，找到您刚刚导入的存档（一般与文件夹同名），双击以游玩。"/>
 		<Image HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/26/6/minecraft-play.png"/>
 	</StackPanel>
 </local:MyCard>

--- a/Minecraft/微软账号登录失败.xaml
+++ b/Minecraft/微软账号登录失败.xaml
@@ -34,10 +34,10 @@
             <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/25/6/Network_Settings.png" />
         </Grid>
 
-        <local:MyHint Margin="0,20,0,0" Text="您也可选择其他国内知名 DNS 提供商提供的 DNS (如 DNSPod)。" IsWarn="False" />
+        <local:MyHint Margin="0,20,0,0" Text="您也可选择其他国内知名 DNS 提供商提供的 DNS（如 DNSPod）。" IsWarn="False" />
         <Grid Margin="0,10,0,0">
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
-                        Text="4. 双击 “Internet 协议版本 4 (TCP/IPv4)”，点击使用下面的 DNS 服务器地址，在“首选 DNS 服务器”内填写“223.5.5.5”，在 “备用 DNS 服务器” 内填写“223.6.6.6”并保存。" HorizontalAlignment="Left" />
+                        Text="4. 双击 “Internet 协议版本 4 (TCP/IPv4)”，点击使用下面的 DNS 服务器地址，在“首选 DNS 服务器”内填写“223.5.5.5”，在 “备用 DNS 服务器” 内填写 “223.6.6.6” 并保存。" HorizontalAlignment="Left" />
             <!-- 此处原 DNS 为微软公用 DNS，鉴于此 DNS 在中国大陆内使用情况不佳，更改为阿里云 DNS -->
             <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/26/6/ControlPanel.DNS.Settings.png" />
         </Grid>
@@ -93,7 +93,7 @@
             <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/10/1/4R.png" />
         </Grid>
 
-        <local:MyHint Margin="0,20,0,0" Text="您也可选择其他国内知名 DNS 提供商提供的 DNS (如 DNSPod)。" IsWarn="False" />
+        <local:MyHint Margin="0,20,0,0" Text="您也可选择其他国内知名 DNS 提供商提供的 DNS（如 DNSPod）。" IsWarn="False" />
         <Grid Margin="0,10,0,0">
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
                         Text="4. 双击 “Internet 协议版本 4 (TCP/IPv4)”，点击使用下面的 DNS 服务器地址，在 “首选 DNS 服务器” 内填写 “223.5.5.5”，在 “备用 DNS 服务器” 内填写 “223.6.6.6” 并保存。" HorizontalAlignment="Left" />

--- a/Minecraft/微软账号登录失败.xaml
+++ b/Minecraft/微软账号登录失败.xaml
@@ -8,7 +8,7 @@
         <TextBlock Margin="0,0,0,4" LineHeight="19"
                    Text="1. 一直卡在正在加载的界面。" />
         <TextBlock Margin="0,0,0,4" LineHeight="19"
-                   Text="2. 可以正常打开，但是登录时弹出&quot;发生错误，请重试&quot;的窗口。或弹出 “哎呀，出错了” 的提示。"  />
+                   Text="2. 可以正常打开，但是登录时弹出 &quot;发生错误，请重试&quot; 的窗口。或弹出 “哎呀，出错了” 的提示。"  />
     </StackPanel>
 </local:MyCard>
 
@@ -16,20 +16,20 @@
 	<StackPanel Margin="25,40,23,15">
         <Grid>
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
-                        Text="1. 在任务栏上找到对应网络状态的图标，右键点击此图标后点击&quot;网络和 Internet 设置&quot;。" HorizontalAlignment="Left" />
+                        Text="1. 在任务栏上找到对应网络状态的图标，右键点击此图标后点击 &quot;网络和 Internet 设置&quot;。" HorizontalAlignment="Left" />
             <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/26/6/Taskbar.NI.Settings.png" />
         </Grid>
         <!-- 更改适配器设置 -->
         <Grid Margin="0,20,0,4">
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
-                        Text="2. Win10: 转到&quot;状态&quot;页面并点击&quot;更改适配器设置&quot;。&#xA; Win11: 点击&quot;高级网络设置&quot;后点击下方的&quot;更多网络适配器选项&quot;。" HorizontalAlignment="Left" />
+                        Text="2. Win10: 转到 &quot;状态&quot; 页面并点击 &quot;更改适配器设置&quot;。&#xA; Win11: 点击 &quot;高级网络设置&quot; 后点击下方的 &quot;更多网络适配器选项&quot;。" HorizontalAlignment="Left" />
             <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/25/6/Adopt_Settings.png" />
             <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/26/6/Win11.Settings.NW.SPQ.png" />
         </Grid>
         <!-- 右键点击你的连接 点击属性 -->
         <Grid Margin="0,20,0,4">
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
-                        Text="3. 右键点击您目前正在连接的网络（一般为&quot;以太网&quot;或&quot;WLAN&quot;），点击属性。" HorizontalAlignment="Left" />
+                        Text="3. 右键点击您目前正在连接的网络（一般为 &quot;以太网&quot; 或 &quot;WLAN&quot;），点击属性。" HorizontalAlignment="Left" />
             <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/10/1/4R.png" />
             <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/25/6/Network_Settings.png" />
         </Grid>
@@ -37,14 +37,14 @@
         <local:MyHint Margin="0,20,0,0" Text="您也可选择其他国内知名 DNS 提供商提供的 DNS (如 DNSPod)。" IsWarn="False" />
         <Grid Margin="0,10,0,0">
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
-                        Text="4. 双击“Internet 协议版本 4 (TCP/IPv4)”，点击使用下面的 DNS 服务器地址，在“首选 DNS 服务器”内填写“223.5.5.5”，在“备用 DNS 服务器”内填写“223.6.6.6”并保存。" HorizontalAlignment="Left" />
+                        Text="4. 双击 “Internet 协议版本 4 (TCP/IPv4)”，点击使用下面的 DNS 服务器地址，在“首选 DNS 服务器”内填写“223.5.5.5”，在 “备用 DNS 服务器” 内填写“223.6.6.6”并保存。" HorizontalAlignment="Left" />
             <!-- 此处原 DNS 为微软公用 DNS，鉴于此 DNS 在中国大陆内使用情况不佳，更改为阿里云 DNS -->
             <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/26/6/ControlPanel.DNS.Settings.png" />
         </Grid>
 
         <Grid Margin="0,20,0,4">
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4"
-                        Text="5. 按住键盘上的 Windows 键 + R 键，输入“ipconfig /flushdns”以刷新 DNS 缓存，接着再次进入 PCL 启动游戏即可正常登录。" />
+                        Text="5. 按住键盘上的 Windows 键 + R 键，输入 “ipconfig /flushdns” 以刷新 DNS 缓存，接着再次进入 PCL 启动游戏即可正常登录。" />
         </Grid>
         <local:MyButton MinWidth="170" Height="35" Padding="10,0" Margin="0,5,20,8" HorizontalAlignment="Left"
                         Text="复制 ipconfig /flushdns 命令" EventType="复制文本" EventData="ipconfig /flushdns" />
@@ -70,40 +70,40 @@
         <!-- 功能开启 -->
         <Grid Margin="0,20,0,4">
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
-                        Text="3. 找到&quot;Microsoft (R) 诊断中心标准收集器服务&quot;，右键点击属性，改成手动，开启服务。" HorizontalAlignment="Left" />
+                        Text="3. 找到 &quot;Microsoft (R) 诊断中心标准收集器服务&quot;，右键点击属性，改成手动，开启服务。" HorizontalAlignment="Left" />
             <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/10/1/11.Microsoft(R).png" />
         </Grid>
 
         <Grid Margin="0,20,0,4">
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
-                        Text="4. 在任务栏上找到对应网络状态的图标，右键点击此图标后&quot;网络和 Internet 设置&quot;。" HorizontalAlignment="Left" />
+                        Text="4. 在任务栏上找到对应网络状态的图标，右键点击此图标后 &quot;网络和 Internet 设置&quot;。" HorizontalAlignment="Left" />
             <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/10/1/Taskbar.NI.Settings.png" />
         </Grid>
         <!-- 更改适配器设置 -->
         <Grid Margin="0,10,0,0">
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
-                        Text="2. Win10: 转到&quot;状态&quot;页面并点击&quot;更改适配器设置&quot;。&#xA; Win11: 点击&quot;高级网络设置&quot;后点击下方的&quot;更多网络适配器选项&quot;。" HorizontalAlignment="Left" />
+                        Text="2. Win10: 转到 &quot;状态&quot; 页面并点击 &quot;更改适配器设置&quot;。&#xA; Win11: 点击 &quot;高级网络设置&quot; 后点击下方的 &quot;更多网络适配器选项&quot;。" HorizontalAlignment="Left" />
             <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/25/6/Adopt_Settings.png" />
             <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/26/6/Win11.Settings.NW.SPQ.png" />
         </Grid>
         <!-- 右键点击你的连接 点击属性 -->
         <Grid Margin="0,20,0,4">
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
-                        Text="3. 右键点击您目前正在连接的网络（一般为&quot;以太网&quot;或&quot;WLAN&quot;），点击属性。" HorizontalAlignment="Left" />
+                        Text="3. 右键点击您目前正在连接的网络（一般为 &quot;以太网&quot; 或 &quot;WLAN&quot;），点击属性。" HorizontalAlignment="Left" />
             <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/10/1/4R.png" />
         </Grid>
 
         <local:MyHint Margin="0,20,0,0" Text="您也可选择其他国内知名 DNS 提供商提供的 DNS (如 DNSPod)。" IsWarn="False" />
         <Grid Margin="0,10,0,0">
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
-                        Text="4. 双击“Internet 协议版本 4 (TCP/IPv4)”，点击使用下面的 DNS 服务器地址，在“首选 DNS 服务器”内填写“223.5.5.5”，在“备用 DNS 服务器”内填写“223.6.6.6”并保存。" HorizontalAlignment="Left" />
+                        Text="4. 双击 “Internet 协议版本 4 (TCP/IPv4)”，点击使用下面的 DNS 服务器地址，在 “首选 DNS 服务器” 内填写 “223.5.5.5”，在 “备用 DNS 服务器” 内填写 “223.6.6.6” 并保存。" HorizontalAlignment="Left" />
             <!-- 此处原 DNS 为微软公用 DNS，鉴于此 DNS 在中国大陆内使用情况不佳，更改为阿里云 DNS -->
             <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/26/6/ControlPanel.DNS.Settings.png" />
         </Grid>
 
         <Grid Margin="0,20,0,4">
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4"
-                        Text="5. 按住键盘上的 Windows 键 + R 键，输入“ipconfig /flushdns”以刷新 DNS 缓存，接着再次进入 PCL 启动游戏即可正常登录。" />
+                        Text="5. 按住键盘上的 Windows 键 + R 键，输入 “ipconfig /flushdns” 以刷新 DNS 缓存，接着再次进入 PCL 启动游戏即可正常登录。" />
         </Grid>
         <local:MyButton MinWidth="170" Height="35" Padding="10,0" Margin="0,5,20,8" HorizontalAlignment="Left"
                         Text="复制 ipconfig /flushdns 命令" EventType="复制文本" EventData="ipconfig /flushdns" />

--- a/Minecraft/数据包安装.xaml
+++ b/Minecraft/数据包安装.xaml
@@ -31,7 +31,7 @@
         <local:MyHint Margin="0,15,0,0" Text="在 Minecraft Java 1.16 版本以下，您需要一个已经创建的世界（存档）才能对这个世界添加数据包" IsWarn="False" />
         <Grid Margin="0,20,0,4">
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
-                        Text="2. 点击“单人游戏”，单击选择您想要安装数据包的世界(不是进入世界)，点击下方&quot;编辑&quot; → &quot;打开世界文件夹&quot;" HorizontalAlignment="Left" />
+                        Text="2. 点击 “单人游戏”，单击选择您想要安装数据包的世界 (不是进入世界)，点击下方 &quot;编辑&quot; → &quot;打开世界文件夹&quot;" HorizontalAlignment="Left" />
             <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/10/1/Edit-World.png" />        
         </Grid>
 
@@ -77,18 +77,18 @@
 
         <Grid Margin="0,20,0,4">
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
-                        Text="1. 参考上方内容启动您想要安装数据包的版本，点击“单人游戏”。" HorizontalAlignment="Left" />
+                        Text="1. 参考上方内容启动您想要安装数据包的版本，点击 “单人游戏”。" HorizontalAlignment="Left" />
             <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/10/1/World-List.png" />        
         </Grid>
-        <local:MyHint Margin="0,15,0,0" Text="如果你还没有创建任何世界则无需点击“创建新的世界”按钮，则直接点击右中“数据包”。&#xa;对于 1.20 及以上版本，你需要在创建世界页面上方单击 “更多” 选项卡以找到 “数据包” 按钮。" IsWarn="False" />
+        <local:MyHint Margin="0,15,0,0" Text="如果你还没有创建任何世界则无需点击 “创建新的世界” 按钮，则直接点击右中 “数据包”。&#xa;对于 1.20 及以上版本，你需要在创建世界页面上方单击 “更多” 选项卡以找到 “数据包” 按钮。" IsWarn="False" />
         <Grid Margin="0,20,0,4">
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
-                        Text="2. 点击下方“创建新的世界”，点击右中“数据包”" HorizontalAlignment="Left" />
+                        Text="2. 点击下方 “创建新的世界”，点击右中 “数据包”" HorizontalAlignment="Left" />
             <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/10/1/Create-World-Datapack.png" />        
         </Grid>
         <Grid Margin="0,20,0,4">
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
-                        Text="3. 打开资源管理器，定位至您准备的数据包，将其拖入 Minecraft 窗口，然后点击“是”" HorizontalAlignment="Left" />
+                        Text="3. 打开资源管理器，定位至您准备的数据包，将其拖入 Minecraft 窗口，然后点击 “是”" HorizontalAlignment="Left" />
             <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/10/1/Drag-and-drop-Datapack.png" />
         </Grid>
         <Grid Margin="0,20,0,4">
@@ -101,7 +101,7 @@
             <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/10/1/Confirm-Install.png" />        
         </Grid>
         <TextBlock TextWrapping="Wrap" Margin="0,15,0,4"
-                   Text="5. 设置一些你想设置的，如世界名称、游戏模式等，点击下方“创建新的世界”进入游戏。"/>
+                   Text="5. 设置一些你想设置的，如世界名称、游戏模式等，点击下方 “创建新的世界” 进入游戏。"/>
     </StackPanel>
 </local:MyCard>
 <local:MyHint Margin="0,0,0,15" Text="作者：jiecs_23、WTP016、CheloverC60" IsWarn="False" />

--- a/Minecraft/数据包安装.xaml
+++ b/Minecraft/数据包安装.xaml
@@ -13,7 +13,7 @@
 <local:MyCard Title="获取数据包" Margin="0,0,0,15">
     <StackPanel Margin="25,40,23,15">
         <TextBlock TextWrapping="Wrap" Margin="0,0,0,4"
-                   Text="数据包和资源包类似，是由 Minecraft 玩家创作并分享的，你可以在网上找到其他玩家制作的数据包。很多 Minecraft 交流网站(如 MCBBS)都有专门的数据包版块，你可以在这些地方挑选自己喜欢的数据包。" />
+                   Text="数据包和资源包类似，是由 Minecraft 玩家创作并分享的，你可以在网上找到其他玩家制作的数据包。很多 Minecraft 交流网站（如 MCBBS）都有专门的数据包版块，你可以在这些地方挑选自己喜欢的数据包。" />
         <local:MyButton Height="35" HorizontalAlignment="Left" Padding="13,0,13,0"
                     Text="打开 MCBBS 数据包板块" EventType="打开网页" EventData="https://www.mcbbs.net/forum-datapack-1.html" />
     </StackPanel>
@@ -31,7 +31,7 @@
         <local:MyHint Margin="0,15,0,0" Text="在 Minecraft Java 1.16 版本以下，您需要一个已经创建的世界（存档）才能对这个世界添加数据包" IsWarn="False" />
         <Grid Margin="0,20,0,4">
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
-                        Text="2. 点击 “单人游戏”，单击选择您想要安装数据包的世界 (不是进入世界)，点击下方 &quot;编辑&quot; → &quot;打开世界文件夹&quot;" HorizontalAlignment="Left" />
+                        Text="2. 点击 “单人游戏”，单击选择您想要安装数据包的世界（不是进入世界），点击下方 &quot;编辑&quot; → &quot;打开世界文件夹&quot;" HorizontalAlignment="Left" />
             <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/10/1/Edit-World.png" />        
         </Grid>
 

--- a/Minecraft/整合包安装.xaml
+++ b/Minecraft/整合包安装.xaml
@@ -12,7 +12,7 @@
 <local:MyCard Title="获取整合包" Margin="0,0,0,15">
     <StackPanel Margin="25,40,23,15">
         <TextBlock TextWrapping="Wrap" Margin="0,0,0,4"
-                   Text="整合包和资源包类似，是由 Minecraft 玩家创作并分享的，你可以在网上找到其他玩家制作的整合包。很多 Minecraft 交流网站(如 MCBBS、CurseForge、Modrinth)都有专门的整合包分享版块，你可以在这些地方挑选自己喜欢的整合包。" />
+                   Text="整合包和资源包类似，是由 Minecraft 玩家创作并分享的，你可以在网上找到其他玩家制作的整合包。很多 Minecraft 交流网站（如 MCBBS、CurseForge、Modrinth）都有专门的整合包分享版块，你可以在这些地方挑选自己喜欢的整合包。" />
         <local:MyButton Height="35" HorizontalAlignment="Left" Padding="13,0,13,0"
                    Text="打开 MCBBS 整合包分享板块" EventType="打开网页" EventData="https://www.mcbbs.net/forum-modpack-1.html" />
     </StackPanel>
@@ -21,7 +21,7 @@
 <local:MyCard Title="安装已有的压缩文件" Margin="0,0,0,15" CanSwap="True" IsSwaped="True">
     <StackPanel Margin="25,40,23,15">
         
-        <local:MyHint Margin="0,0,0,15" Text="注意: 以下情况假设您已下载好整合包(通常是为 .zip / .rar 结尾的文件)。" IsWarn="False" />
+        <local:MyHint Margin="0,0,0,15" Text="注意: 以下情况假设您已下载好整合包（通常是为 .zip / .rar 结尾的文件）。" IsWarn="False" />
         <Grid>
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
                         Text="对于结尾为 .zip / .rar 的压缩文件整合包，您需打开 PCL 启动器，点击 “下载” 按钮后选择左侧菜单 “资源” 分类下的 “整合包” 选项，点击 “安装整合包” 按钮并选择你下载好的本地整合包。此处以 “Example.zip” 为案例。" HorizontalAlignment="Left" />

--- a/Minecraft/资源包安装.xaml
+++ b/Minecraft/资源包安装.xaml
@@ -4,7 +4,7 @@
 <local:MyCard Title="获取资源包" Margin="0,0,0,15">
     <StackPanel Margin="25,40,23,15">
         <TextBlock TextWrapping="Wrap" Margin="0,0,0,4"
-                   Text="资源包和光影类似，是由 Minecraft 玩家创作并分享的，你可以在网上找到其他玩家制作的光影包。很多 Minecraft 交流网站(如 MCBBS)都有专门的资源包版块，你可以在这些地方挑选自己喜欢的资源包。" />
+                   Text="资源包和光影类似，是由 Minecraft 玩家创作并分享的，你可以在网上找到其他玩家制作的光影包。很多 Minecraft 交流网站（如 MCBBS）都有专门的资源包版块，你可以在这些地方挑选自己喜欢的资源包。" />
         <local:MyButton Height="35" HorizontalAlignment="Left" Padding="13,0,13,0"
                    Text="打开 MCBBS 资源包板块" EventType="打开网页" EventData="https://www.mcbbs.net/forum-texture-1.html" />
     </StackPanel>

--- a/Minecraft/资源包安装.xaml
+++ b/Minecraft/资源包安装.xaml
@@ -32,7 +32,7 @@
 
         <Grid Margin="0,20,0,4">
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
-                        Text="4. 打开 “resourcepacks” 文件夹，并将您的资源包拖入 ”resourcepacks“ 文件夹。" HorizontalAlignment="Left" />
+                        Text="4. 打开 “resourcepacks” 文件夹，并将您的资源包拖入 “resourcepacks” 文件夹。" HorizontalAlignment="Left" />
             <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/26/6/explorer-prepared-put-into-resourcepack-folder.png" />
         </Grid>
         <local:MyHint Margin="0,15,0,0" Text="注意：部分资源包压缩包主体内套入了一个文件夹，此时你可以直接将此文件夹解压至 “resourcepacks” 文件夹使用。（如下图）" IsWarn="False" />

--- a/启动器/LittleSkin 外置登录使用教程.xaml
+++ b/启动器/LittleSkin 外置登录使用教程.xaml
@@ -27,19 +27,19 @@
 
         <Grid Margin="0,20,0,4">
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
-                        Text="2. 进入“仪表盘”，点击左侧“角色管理”，再点击“添加新角色”。" HorizontalAlignment="Left" />
+                        Text="2. 进入 “仪表盘”，点击左侧 “角色管理”，再点击 “添加新角色”。" HorizontalAlignment="Left" />
             <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/10/1/img2.png" />
         </Grid>
 
         <Grid Margin="0,20,0,4">
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
-                        Text="3. 在弹出的窗口内输入角色名（这将会成为联机时的 ID，即游戏中的用户名），填写完成后点击“确定”。" HorizontalAlignment="Left" />
+                        Text="3. 在弹出的窗口内输入角色名（这将会成为联机时的 ID，即游戏中的用户名），填写完成后点击 “确定”。" HorizontalAlignment="Left" />
             <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2022/07/10/1/img3.png" />
         </Grid>
 
         <Grid Margin="0,20,0,4">
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
-                        Text="4. 打开 PCL，点击左下角的“版本选择”。" HorizontalAlignment="Left" />
+                        Text="4. 打开 PCL，点击左下角的 “版本选择”。" HorizontalAlignment="Left" />
             <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2023/02/19/63f20230b5136.png" />
         </Grid>
 
@@ -51,26 +51,26 @@
 
         <Grid Margin="0,20,0,4">
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
-                        Text="6. 点击左侧“设置”选项。" HorizontalAlignment="Left" />
+                        Text="6. 点击左侧 “设置” 选项。" HorizontalAlignment="Left" />
             <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2023/02/19/63f20230bedd5.png" />
         </Grid>
 
         <Grid Margin="0,20,0,4">
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
-                        Text="7. 滑动到页面底部，在“服务器选项”中把登录方式设为“第三方登录：Authlib Injector 或 LittleSkin”。" HorizontalAlignment="Left" />
+                        Text="7. 滑动到页面底部，在“服务器选项”中把登录方式设为 “第三方登录：Authlib Injector 或 LittleSkin”。" HorizontalAlignment="Left" />
             <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2023/02/20/63f36df35222d.png" />
         </Grid>
 
         <Grid Margin="0,20,0,4">
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
-                        Text="8. 点击下方“设置为 LittleSkin”按钮。" HorizontalAlignment="Left" />
+                        Text="8. 点击下方 “设置为 LittleSkin” 按钮。" HorizontalAlignment="Left" />
             <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2023/02/20/63f36e0268931.png" />
         </Grid>
 
         <local:MyHint Margin="0,20,0,0" Text="在启动游戏后，PCL 能够记忆你的账号，并且可以进行更换角色、更改皮肤、退出登录等操作。" IsWarn="False" />
         <Grid Margin="0,10,0,0">
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
-                        Text="9. 返回主页并输入你的 LittleSkin 账号，点击“启动游戏”即可。" HorizontalAlignment="Left" />
+                        Text="9. 返回主页并输入你的 LittleSkin 账号，点击 “启动游戏” 即可。" HorizontalAlignment="Left" />
             <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2023/02/20/63f36e13ba79e.png" />
         </Grid>
     </StackPanel>

--- a/启动器/指定登录方式.xaml
+++ b/启动器/指定登录方式.xaml
@@ -13,7 +13,7 @@
 	<StackPanel Margin="25,40,23,15">
         <Grid>
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
-                        Text="1. 点击启动页面下方的“版本选择”。" HorizontalAlignment="Left" />
+                        Text="1. 点击启动页面下方的 “版本选择”。" HorizontalAlignment="Left" />
             <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2023/02/19/63f20230b5136.png" />
         </Grid>
 
@@ -25,13 +25,13 @@
 
         <Grid Margin="0,20,0,4">
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
-                        Text="3. 点击左侧“设置”按钮。" HorizontalAlignment="Left" />
+                        Text="3. 点击左侧 “设置” 按钮。" HorizontalAlignment="Left" />
             <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2023/02/19/63f20230bedd5.png" />
         </Grid>
 
         <Grid Margin="0,20,0,4">
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
-                        Text="4. 滑动至下方，在“服务器”中选择登录方式即可切换。" HorizontalAlignment="Left" />
+                        Text="4. 滑动至下方，在 “服务器” 中选择登录方式即可切换。" HorizontalAlignment="Left" />
             <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://cdn.img.z0z0r4.top/2023/05/13/645f36c487851.png" />
         </Grid>
     </StackPanel>


### PR DESCRIPTION
#312 的后续。此 Pr 检查了所有 PCL2 帮助库中的页面，在引号前后添加了空格。可能会有眼瞎的一两个漏网之鱼qwq……这两天我再复查几遍，谢谢啦！orz

正好在这里顺便问一下，是否有必要统一英文括号为中文括号，有些帮助页面中英文括号在一篇文章里混用，有失整齐性，根据帮助库规范，应该全部使用中文括号来着。因为数量有点多，我就改了几个 OwO，看看您的意见