### PR TITLE
更换 Wiki 链接

### DIFF
--- a/百科/Minecraft Wiki.json
+++ b/百科/Minecraft Wiki.json
@@ -1,10 +1,10 @@
 {
-	"__Author__": "NotKiller233、龙腾猫跃",
+	"__Author__": "NotKiller233、龙腾猫跃、风释清然SC",
 	"Title": "原版百科",
 	"Description": "Minecraft Wiki：包含原版游戏过程中所需大多数知识的中文百科",
 	"Keywords": "我的世界wikipedia",
 	"Types": ["百科"],
 	"IsEvent": true,
 	"EventType": "打开网页",
-	"EventData": "https://wiki.biligame.com/mc/Minecraft_Wiki"
+	"EventData": "https://zh.minecraft.wiki/w/Minecraft_Wiki"
 }


### PR DESCRIPTION
当前中文百科尚未迁移，因此这个 pr 暂时不必合并。
鉴于迁移过后国内访问速度较快且更新速度快于当前正在使用的 BWiki，因此进行替换。
手机上编辑的，如果中文 wiki 迁移后网址有变动我会修改 :)