### PR TITLE
规范化帮助库页面

### DIFF
--- a/Minecraft/安装光影.json
+++ b/Minecraft/安装光影.json
@@ -1,5 +1,5 @@
 {
-    "__Author__": "Logic_530",
+    "__Author__": "Logic_530、风释清然SC",
 	"Title": "安装光影",
 	"Description": "使用 OptiFine 或 Iris Shaders 导入光影包",
 	"Types": ["Minecraft"]

--- a/Minecraft/安装光影.xaml
+++ b/Minecraft/安装光影.xaml
@@ -1,15 +1,13 @@
-<!--图片备份：https://github.com/WForst-Breeze/Files/tree/main/PCL2/H_img_shaders-->
+<!--SC图片备份：https://github.com/WForst-Breeze/Files/tree/main/PCL2/H_img_shaders-->
 
 <local:MyCard Title="选择光影加载器" Margin="0,0,0,15">
     <StackPanel Margin="25,40,23,15">
         <TextBlock TextWrapping="Wrap" Margin="0,0,0,4"
-                   Text="目前提供光影功能的 Mod 有 OptiFine 和 Iris Shaders。其中 Optifine 支持 Forge 加载器（可以通过 OptiFabric Mod 兼容 Fabric），Iris Shaders 支持 Fabric 和 Quilt 加载器。" />
+                   Text="目前提供光影功能的 Mod 有 OptiFine 和 Iris Shaders。其中 OptiFine 支持 Forge（可以通过 OptiFabric Mod 兼容 Fabric），Iris Shaders 支持 Fabric 和 Quilt。" />
         <TextBlock TextWrapping="Wrap" Margin="0,0,0,4"
                    Text= "OptiFine 几乎支持所有的 Minecraft 版本，而 Iris Shaders 目前只支持 1.16 及更高版本。" />
         <TextBlock TextWrapping="Wrap" Margin="0,0,0,4"
-                   Text="由于 Optifine 闭源，因此在整合包中可能会导致模组冲突、渲染错误或游戏崩溃，但 Optifine 拓展了 Minecraft 游戏内视觉方面的自定义内容和资源包内容，同时在部分版本可以显著提高 FPS。因此对于 1.16 及以下版本，推荐使用 Optifine。" />
-        <TextBlock TextWrapping="Wrap" Margin="0,0,0,4"
-                   Text="Iris Shaders 支持的游戏版本较少，但其支持的 Sodium Mod 对图像性能的优化效果显著且兼容性较好，其表现在较高版本通常优于 OptiFine。因此对于 1.16 及以上版本，推荐使用 Iris Shaders。" />
+                   Text="综合考量，对于 1.16 以下版本，推荐使用 OptiFine；而对于 1.16 及以上版本，推荐使用 Iris Shaders。" />
     </StackPanel>
 </local:MyCard>
 
@@ -24,10 +22,10 @@
 
 <local:MyCard Title="安装 OptiFine" Margin="0,0,0,15" CanSwap="True" IsSwaped="True">
     <StackPanel Margin="25,40,23,15">
-        <local:MyHint Margin="0,4,0,0" Text="若您需要在 Fabric 加载器下加载 Optifine，直接在自动安装页面选择你想要安装的 Fabric 版本即可，PCL 会自动为你选择安装合适的 Fabric API 和 OptiFabric。" IsWarn="False" />
+        <local:MyHint Margin="0,4,0,0" Text="若您需要在 Fabric 中加载 OptiFine，直接在自动安装页面选择你想要安装的 Fabric 版本即可，PCL 会自动为你选择安装合适的 Fabric API 和 OptiFabric。" IsWarn="False" />
         <Grid Margin="0,10,0,4">
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
-                        Text="如果你选择使用 OptiFine，进入 “自动安装” 页面，选择 Minecraft 版本后选择合适的 Optifine 版本，点击 “开始安装” 按钮即可安装。" HorizontalAlignment="Left" />
+                        Text="如果你选择使用 OptiFine，进入 “自动安装” 页面，选择 Minecraft 版本后选择合适的 OptiFine 版本，点击 “开始安装” 按钮即可安装。" HorizontalAlignment="Left" />
             <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://img.z0z0r4.top/local/2023/11/05/654770cb669e5.png" />
         </Grid>
     </StackPanel>
@@ -58,9 +56,9 @@
         </Grid>
 
         <TextBlock Margin="0,12,0,7" FontSize="19" Foreground="{DynamicResource ColorBrush2}"
-                   Text="Optifine" />
+                   Text="OptiFine" />
         
-        <local:MyHint Margin="0,4,0,0" Text="Optifine 会在你选择光影后直接开始加载此光影，请在选择前确认该光影是否为你想启用的光影以避免长时间的等待。" IsWarn="False" />
+        <local:MyHint Margin="0,4,0,0" Text="OptiFine 会在你选择光影后直接开始加载此光影，请在选择前确认该光影是否为你想启用的光影以避免长时间的等待。" IsWarn="False" />
         <Grid Margin="0,10,0,4">
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
                         Text="进入游戏后顺次点击 “选项” → “视频设置” → “光影”，点击你想要应用的光影即可。" HorizontalAlignment="Left" />

--- a/Minecraft/安装光影.xaml
+++ b/Minecraft/安装光影.xaml
@@ -14,9 +14,15 @@
 <local:MyCard Title="获取光影包" Margin="0,0,0,15">
     <StackPanel Margin="25,40,23,15">
         <TextBlock TextWrapping="Wrap" Margin="0,0,0,4"
-                   Text="光影包和资源包类似，是由 Minecraft 玩家创作并分享的，你可以在网上找到其他玩家制作的光影包。很多 Minecraft 交流网站（如 MCBBS）都有专门的光影版块，你可以在这些地方挑选自己喜欢的光影包。OptiFine 也提供了一个分享光影包的网站，在光影设置界面点击光影包文件夹旁的下载按钮即可。" />
-        <local:MyButton Height="35" HorizontalAlignment="Left" Padding="13,0,13,0" Margin="0,4,20,0"
-                   Text="打开 MCBBS 光影分享板块" EventType="打开网页" EventData="https://www.mcbbs.net/forum.php?mod=forumdisplay&amp;fid=1357" />
+                   Text="你可以在许多相关资源网站找到光影包，诸如 MCBBS、CurseForge、Modrinth。你可以点击下面的按钮来快速跳转至这些网站：" />
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Left">
+            <local:MyButton Margin="0,4,20,0" Height="35" HorizontalAlignment="Left" Padding="13,0,13,0"
+                        Text="MCBBS 光影分享板块" EventType="打开网页" EventData="https://www.mcbbs.net/forum.php?mod=forumdisplay&amp;fid=1357&amp;filter=typeid&amp;typeid=2376" />
+            <local:MyButton Margin="0,4,20,0" Height="35" HorizontalAlignment="Left" Padding="13,0,13,0"
+                        Text="CurseForge 光影下载" EventType="打开网页" EventData="https://www.curseforge.com/minecraft/search?class=shaders" />
+            <local:MyButton Margin="0,4,20,0" Height="35" HorizontalAlignment="Left" Padding="13,0,13,0"
+                        Text="Modrinth 光影下载" EventType="打开网页" EventData="https://modrinth.com/shaders" />
+        </StackPanel>
     </StackPanel>
 </local:MyCard>
 

--- a/Minecraft/安装光影.xaml
+++ b/Minecraft/安装光影.xaml
@@ -1,65 +1,82 @@
-<local:MyHint Margin="0,0,0,15" Text="该帮助页面还需要根据规范重新整理格式，优化排版与文案。如果你感兴趣也可以来帮帮忙！" IsWarn="False" />
+<!--图片备份：https://github.com/WForst-Breeze/Files/tree/main/PCL2/H_img_shaders-->
 
-<local:MyCard Title="光影是什么？" Margin="0,0,0,15">
+<local:MyCard Title="选择光影加载器" Margin="0,0,0,15">
     <StackPanel Margin="25,40,23,15">
         <TextBlock TextWrapping="Wrap" Margin="0,0,0,4"
-                   Text="光影（Shader）是通过游戏 Mod 实现的一项画面修改功能，玩家可以通过加载光影包（Shader Pack）来修改 Minecraft 的画面渲染方式，使得游戏画面更为美观或具有风格。" />
+                   Text="目前提供光影功能的 Mod 有 OptiFine 和 Iris Shaders。其中 Optifine 支持 Forge 加载器（可以通过 OptiFabric Mod 兼容 Fabric），Iris Shaders 支持 Fabric 和 Quilt 加载器。" />
         <TextBlock TextWrapping="Wrap" Margin="0,0,0,4"
-                   Text="目前提供光影功能的 Mod 有 OptiFine 和 Iris Shaders，前者支持 Forge 加载器（可以通过 OptiFabric Mod 兼容 Fabric）而后者支持 Fabric 加载器。OptiFine 几乎支持所有的 Minecraft 版本而 Iris Shaders 作为新兴的光影 Mod，目前只支持 1.16.5 及更高版本。一般情况下，OptiFine 是使用光影的最佳选择。" />
-        <local:MyHint Margin="0,0,0,7" IsWarn="False"
-                   Text="虽然 Iris Shaders 支持的游戏版本较少，但其支持的 Sodium Mod 对图像性能的优化效果显著，甚至优于 OptiFine。如果你游玩的版本能够使用，不妨先尝试 Iris Shaders。" />
-        <local:MyHint Margin="0,0,0,7" IsWarn="False"
-                   Text="从 1.1.3 版本开始，Iris Shaders 不再自带 Sodium Mod，你需要额外下载 Sodium Mod。" />
+                   Text= "OptiFine 几乎支持所有的 Minecraft 版本，而 Iris Shaders 目前只支持 1.16 及更高版本。" />
+        <TextBlock TextWrapping="Wrap" Margin="0,0,0,4"
+                   Text="由于 Optifine 闭源，因此在整合包中可能会导致模组冲突、渲染错误或游戏崩溃，但 Optifine 拓展了 Minecraft 游戏内视觉方面的自定义内容和资源包内容，同时在部分版本可以显著提高 FPS。因此对于 1.16 及以下版本，推荐使用 Optifine。" />
+        <TextBlock TextWrapping="Wrap" Margin="0,0,0,4"
+                   Text="Iris Shaders 支持的游戏版本较少，但其支持的 Sodium Mod 对图像性能的优化效果显著且兼容性较好，其表现在较高版本通常优于 OptiFine。因此对于 1.16 及以上版本，推荐使用 Iris Shaders。" />
+    </StackPanel>
+</local:MyCard>
+
+<local:MyCard Title="获取光影包" Margin="0,0,0,15">
+    <StackPanel Margin="25,40,23,15">
+        <TextBlock TextWrapping="Wrap" Margin="0,0,0,4"
+                   Text="光影包和资源包类似，是由 Minecraft 玩家创作并分享的，你可以在网上找到其他玩家制作的光影包。很多 Minecraft 交流网站（如 MCBBS）都有专门的光影版块，你可以在这些地方挑选自己喜欢的光影包。OptiFine 也提供了一个分享光影包的网站，在光影设置界面点击光影包文件夹旁的下载按钮即可。" />
+        <local:MyButton Height="35" HorizontalAlignment="Left" Padding="13,0,13,0" Margin="0,4,20,0"
+                   Text="打开 MCBBS 光影分享板块" EventType="打开网页" EventData="https://www.mcbbs.net/forum.php?mod=forumdisplay&amp;fid=1357" />
     </StackPanel>
 </local:MyCard>
 
 <local:MyCard Title="安装 OptiFine" Margin="0,0,0,15" CanSwap="True" IsSwaped="True">
     <StackPanel Margin="25,40,23,15">
-        <TextBlock TextWrapping="Wrap" Margin="0,0,0,4"
-                   Text="如果你选择使用 OptiFine，PCL 可以为下载的 Minecraft 版本自动安装 OptiFine，使用自动安装功能时展开“OptiFine”菜单，选择需要的版本即可。" />
-        <Image HorizontalAlignment="Center" Source="https://img.z0z0r4.top/local/2022/07/25/6/OptiFine_Install_with_Game.png" />
-        <local:MyHint Margin="0,0,0,7" IsWarn="False"
-                   Text="OptiFine 可以通过安装 OptiFabric Mod 兼容 Fabric 加载器，在 PCL 最新版本中使用自动安装功能时同时选择&quot;OptiFine&quot;、&quot;OptiFabric&quot;、&quot;Fabric&quot;和&quot;Fabric API&quot;即可。" />
+        <local:MyHint Margin="0,4,0,0" Text="若您需要在 Fabric 加载器下加载 Optifine，直接在自动安装页面选择你想要安装的 Fabric 版本即可，PCL 会自动为你选择安装合适的 Fabric API 和 OptiFabric。" IsWarn="False" />
+        <Grid Margin="0,10,0,4">
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
+                        Text="如果你选择使用 OptiFine，进入 “自动安装” 页面，选择 Minecraft 版本后选择合适的 Optifine 版本，点击 “开始安装” 按钮即可安装。" HorizontalAlignment="Left" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://img.z0z0r4.top/local/2023/11/05/654770cb669e5.png" />
+        </Grid>
     </StackPanel>
 </local:MyCard>
 
 <local:MyCard Title="安装 Iris Shaders" Margin="0,0,0,15" CanSwap="True" IsSwaped="True">
     <StackPanel Margin="25,40,23,15">
         <TextBlock TextWrapping="Wrap" Margin="0,0,0,4"
-                   Text="如果你选择使用 Iris Shaders，PCL 提供的 Mod 下载功能可以帮助你下载这个 Mod。在 Mod 下载界面搜索“Iris Shaders”即可找到此 Mod。" />
-        <local:MyHint Margin="0,0,0,7" IsWarn="False"
-                   Text="关于安装 Mod 的详细说明，请查看帮助“安装 Mod”。" />
-    </StackPanel>
-</local:MyCard>
-
-
-<local:MyCard Title="获取光影包" Margin="0,0,0,15">
-    <StackPanel Margin="25,40,23,15">
-        <TextBlock TextWrapping="Wrap" Margin="0,0,0,4"
-                   Text="光影包和资源包类似，是由 Minecraft 玩家创作并分享的，你可以在网上找到其他玩家制作的光影包。很多 Minecraft 交流网站(如 MCBBS)都有专门的光影版块，你可以在这些地方挑选自己喜欢的光影包。OptiFine 也提供了一个分享光影包的网站，在光影设置界面点击光影包文件夹旁的下载按钮即可打开（英文网站）。" />
-        <local:MyButton Height="35" HorizontalAlignment="Left" Padding="13,0,13,0"
-                   Text="打开 MCBBS 光影分享板块" EventType="打开网页" EventData="https://www.mcbbs.net/forum.php?mod=forumdisplay&amp;fid=1357" />
+                   Text="如果你选择使用 Iris Shaders，在 Mod 下载界面搜索 “Iris Shaders” 即可。如果你尚不清楚如何使用 PCL 安装 Mod，可以查看此教程：" />
+        <local:MyListItem Margin="0,0,0,4" SnapsToDevicePixels="True" Type="Clickable" PaddingRight="4"
+		            EventType="打开帮助" EventData="Minecraft/安装 Mod.json" />
     </StackPanel>
 </local:MyCard>
 
 <local:MyCard Title="导入并启用光影包" Margin="0,0,0,15">
     <StackPanel Margin="25,40,23,15">
-        <TextBlock TextWrapping="Wrap" Margin="0,0,0,4"
-                   Text="光影包下载完成后需要导入方可在游戏中使用，OptiFine 和 Iris Shaders 导入光影包的操作相同，只需将光影包放入 .minecraft/shaderpacks 文件夹即可。如果你不清楚怎么找到这个文件夹，可以在进入游戏后，点击 选项-视频设置-光影-光影包 文件夹，游戏会自动为你打开文件夹。" />
-        <TextBlock TextWrapping="Wrap" Margin="0,0,0,4"
-                   Text="如果你使用的是 Iris Shaders，还可以在光影设置界面（选项-视频设置-光影包…）直接将光影包文件拖放到 Minecraft 窗口内完成导入。" />
-        <local:MyHint Margin="0,0,0,7" IsWarn="False"
-                   Text="光影包不区分 OptiFine 或 Iris Shaders，理论上任何光影包都可以在两个 Mod 中使用。" />
-        <local:MyHint Margin="0,0,0,7" IsWarn="False"
-                   Text="光影包下载完成后一般是 .zip 压缩文件的形式，直接放入光影包文件夹即可，不需要解压。" />
-        <local:MyHint Margin="0,0,0,7" IsWarn="False"
-                   Text="有时光影包的作者会依据光影包对电脑性能的需求高低制作多个版本的光影包，并打包成一个压缩包方便玩家下载，此时则需要将大压缩包中的每个光影包提取出来才能使用。" />
-        <TextBlock TextWrapping="Wrap" Margin="0,0,0,4"
-                   Text="导入完成后，在光影设置界面（选项-视频设置-光影…）可以看到已经导入的光影包，点击即可启用。" />
-        <Image HorizontalAlignment="Center" Source="https://img.z0z0r4.top/local/2022/07/10/1/Shader-List.png" />
-        <TextBlock TextWrapping="Wrap" Margin="0,0,0,4"
-                   Text="你还可以在光影设置界面对光影的效果做进一步调整，右侧列出的是 OptiFine 提供的通用选项，点击右下角的光影设置可以打开当前光影包的专有选项，以便对光影的效果作出更多调整。" />
+        <Grid Margin="0,0,0,4">
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
+                        Text="1. 在版本选择中选择需要安装光影的版本，点击 “版本设置”。" HorizontalAlignment="Left" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://img.z0z0r4.top/local/2023/11/05/65477d6b6278a.png" />
+        </Grid>
+        
+        <local:MyHint Margin="0,4,0,0" Text="若未找到 shaderpacks 文件夹，你可以手动创建一个。" IsWarn="False" />
+        <Grid Margin="0,10,0,4">
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
+                        Text="2. 点击 “版本文件夹”，在弹出的文件夹中找到并进入 shaderpacks 文件夹，将你要安装的光影包拖入该文件夹。启动游戏。" HorizontalAlignment="Left" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://img.z0z0r4.top/local/2023/11/05/65477d81185d5.png" />
+        </Grid>
+
+        <TextBlock Margin="0,12,0,7" FontSize="19" Foreground="{DynamicResource ColorBrush2}"
+                   Text="Optifine" />
+        
+        <local:MyHint Margin="0,4,0,0" Text="Optifine 会在你选择光影后直接开始加载此光影，请在选择前确认该光影是否为你想启用的光影以避免长时间的等待。" IsWarn="False" />
+        <Grid Margin="0,10,0,4">
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
+                        Text="进入游戏后顺次点击 “选项” → “视频设置” → “光影”，点击你想要应用的光影即可。" HorizontalAlignment="Left" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://img.z0z0r4.top/local/2023/11/05/65477db23053c.png" />
+        </Grid>
+        
+        <TextBlock Margin="0,12,0,7" FontSize="19" Foreground="{DynamicResource ColorBrush2}"
+                   Text="Iris Shaders" />
+        
+        <local:MyHint Margin="0,4,0,0" Text="如果你在世界中打开光影包页面，则在选择后可以先点击 “应用” 按钮来预览光影包效果后再点击 “完成”。" IsWarn="False" />
+        <Grid Margin="0,10,0,4">
+            <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
+                        Text="进入游戏后顺次点击 “选项” → “视频设置” → “光影包”，选择你想要应用的光影后点击 “完成”。" HorizontalAlignment="Left" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://img.z0z0r4.top/local/2023/11/05/65477da284435.png" />
+        </Grid>
     </StackPanel>
 </local:MyCard>
 
-<local:MyHint Margin="0,0,0,15" Text="作者：Logic_530" IsWarn="False" />
+<local:MyHint Margin="0,0,0,15" Text="作者：Logic_530、风释清然SC" IsWarn="False" />

--- a/Minecraft/安装光影.xaml
+++ b/Minecraft/安装光影.xaml
@@ -6,8 +6,6 @@
                    Text="目前提供光影功能的 Mod 有 OptiFine 和 Iris Shaders。其中 OptiFine 支持 Forge（可以通过 OptiFabric Mod 兼容 Fabric），Iris Shaders 支持 Fabric 和 Quilt。" />
         <TextBlock TextWrapping="Wrap" Margin="0,0,0,4"
                    Text= "OptiFine 几乎支持所有的 Minecraft 版本，而 Iris Shaders 目前只支持 1.16 及更高版本。" />
-        <TextBlock TextWrapping="Wrap" Margin="0,0,0,4"
-                   Text="综合考量，对于 1.16 以下版本，推荐使用 OptiFine；而对于 1.16 及以上版本，推荐使用 Iris Shaders。" />
     </StackPanel>
 </local:MyCard>
 

--- a/Minecraft/整合包安装.xaml
+++ b/Minecraft/整合包安装.xaml
@@ -45,7 +45,7 @@
             <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://img.z0z0r4.top/local/2023/04/09/6432ac7454dd1.png?comment=打开整合包页面" />
         </Grid>
 
-        <local:MyHint Margin="0,20,0,0" Text="搜索时请尽量使用 Mod 的英文名称。" IsWarn="False" />
+        <local:MyHint Margin="0,20,0,0" Text="搜索时请使用整合包的英文名称。" IsWarn="False" />
         <Grid Margin="0,10,0,0">
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
                         Text="2. 在左侧页面中通过选择或输入您所需整合包的名称、类型、来源、游戏版本以筛选并搜索整合包。" HorizontalAlignment="Left" />

--- a/Minecraft/整合包安装.xaml
+++ b/Minecraft/整合包安装.xaml
@@ -1,5 +1,5 @@
-<local:MyHint Margin="0,0,0,15" Text="该帮助页面还需要进一步完善，优化排版与文案。如果你感兴趣也可以来帮帮忙！" IsWarn="False" />
 <!-- 图片备份: https://github.com/WTP016-CN/Image_for_PCL2Help/tree/modpack -->
+<!-- SC 图片备份: https://github.com/WForst-Breeze/Files/tree/main/PCL2/H_img_modpack -->
 
 <local:MyCard Title="整合包是什么?" Margin="0,0,0,15">
     <StackPanel Margin="25,40,23,15">
@@ -21,24 +21,18 @@
 <local:MyCard Title="安装已有的压缩文件" Margin="0,0,0,15" CanSwap="True" IsSwaped="True">
     <StackPanel Margin="25,40,23,15">
         
-        <local:MyHint Margin="0,0,0,15" Text="注意: 以下情况假设您已下载好整合包（通常是为 .zip / .rar 结尾的文件）。" IsWarn="False" />
+        <local:MyHint Margin="0,0,0,15" Text="以下情况假设您已下载好整合包文件。&#xa;若拖入文件时鼠标指针显示禁止符号，请检查是否以管理员身份打开了 PCL 并重启 PCL。" IsWarn="False" />
+        
         <Grid>
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
-                        Text="对于结尾为 .zip / .rar 的压缩文件整合包，您需打开 PCL 启动器，点击 “下载” 按钮后选择左侧菜单 “资源” 分类下的 “整合包” 选项，点击 “安装整合包” 按钮并选择你下载好的本地整合包。此处以 “Example.zip” 为案例。" HorizontalAlignment="Left" />
-            <StackPanel Margin="250,0,0,0">
-                <Image Source="https://img.z0z0r4.top/local/2022/07/26/6/Modpack_Install_Directio.png" />
-                <Image Source="https://img.z0z0r4.top/local/2022/07/26/6/Modpack_Choose.png" />
-            </StackPanel>
+                        Text="1. 将整合包文件拖入 PCL 窗口。" HorizontalAlignment="Left" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://img.z0z0r4.top/local/2023/11/05/654745b7a6112.png?comment=拖入" />
         </Grid>
 
-        <Grid Margin="0,20,0,4">
+        <Grid>
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
-                        Text="此时 PCL 会弹出 “输入版本名” 的窗口，您可自由输入。点击 “确定” 后，PCL 自动开始安装。安装完毕后，您即可在版本列表选择以您输入的版本名为标题的整合包以开始游玩。" HorizontalAlignment="Left" />
-            <StackPanel Margin="250,0,0,0">
-                <Image Source="https://img.z0z0r4.top/local/2022/07/26/6/Input_Game_Name.png" />
-                <Image Source="https://img.z0z0r4.top/local/2022/07/26/6/Game_Launch.png" />
-                <Image Source="https://img.z0z0r4.top/local/2022/07/26/6/Game_Launch_Home.png" />
-            </StackPanel>
+                        Text="2. 输入版本名称后点击 “确定”，等待 PCL 安装完成。" HorizontalAlignment="Left" />
+            <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://img.z0z0r4.top/local/2023/11/05/654748c679b27.png?comment=命名" />
         </Grid>
     </StackPanel>
 </local:MyCard>
@@ -60,7 +54,7 @@
 
         <Grid Margin="0,20,0,4">
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
-                        Text="3. 选择一个整合包。本教程使用 &quot;RLCraft&quot; 为范例。点击此整合包，点击您需要下载的版本，PCL 会自动弹出输入版本名的窗口，您可自由输入，此处以 “RLCraft” 为范例，点击确定，PCL 会自动开始下载。" HorizontalAlignment="Left" />
+                        Text="3. 选择一个整合包后，点击您需要下载的版本，在弹出的窗口输入版本名称，点击 “确定”，等待 PCL 安装完成。" HorizontalAlignment="Left" />
             <Image Margin="250,0,0,0" HorizontalAlignment="Center" Source="https://img.z0z0r4.top/local/2022/07/26/6/modpack_name_input.png" />
         </Grid>
 

--- a/Minecraft/整合包安装.xaml
+++ b/Minecraft/整合包安装.xaml
@@ -20,8 +20,6 @@
                         Text="CurseForge 整合包下载" EventType="打开网页" EventData="https://www.curseforge.com/minecraft/search?class=modpacks" />
             <local:MyButton Margin="0,4,20,0" Height="35" HorizontalAlignment="Left" Padding="13,0,13,0"
                         Text="Modrinth 整合包下载" EventType="打开网页" EventData="https://modrinth.com/shaders" />
-            <local:MyButton Margin="0,4,20,0" Height="35" HorizontalAlignment="Left" Padding="13,0,13,0"
-                        Text="FTB 整合包下载" EventType="打开网页" EventData="https://feed-the-beast.com/modpacks" />
         </StackPanel>
     </StackPanel>
 </local:MyCard>

--- a/Minecraft/整合包安装.xaml
+++ b/Minecraft/整合包安装.xaml
@@ -12,9 +12,17 @@
 <local:MyCard Title="获取整合包" Margin="0,0,0,15">
     <StackPanel Margin="25,40,23,15">
         <TextBlock TextWrapping="Wrap" Margin="0,0,0,4"
-                   Text="整合包和资源包类似，是由 Minecraft 玩家创作并分享的，你可以在网上找到其他玩家制作的整合包。很多 Minecraft 交流网站（如 MCBBS、CurseForge、Modrinth）都有专门的整合包分享版块，你可以在这些地方挑选自己喜欢的整合包。" />
-        <local:MyButton Height="35" HorizontalAlignment="Left" Padding="13,0,13,0"
-                   Text="打开 MCBBS 整合包分享板块" EventType="打开网页" EventData="https://www.mcbbs.net/forum-modpack-1.html" />
+                   Text="你可以在许多相关资源网站找到整合包，诸如 MCBBS、CurseForge、Modrinth、FTB。你可以点击下面的按钮来快速跳转至这些网站：" />
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Left">
+            <local:MyButton Margin="0,4,20,0" Height="35" HorizontalAlignment="Left" Padding="13,0,13,0"
+                        Text="MCBBS 整合包分享板块" EventType="打开网页" EventData="https://www.mcbbs.net/forum-modpack-1.html" />
+            <local:MyButton Margin="0,4,20,0" Height="35" HorizontalAlignment="Left" Padding="13,0,13,0"
+                        Text="CurseForge 整合包下载" EventType="打开网页" EventData="https://www.curseforge.com/minecraft/search?class=modpacks" />
+            <local:MyButton Margin="0,4,20,0" Height="35" HorizontalAlignment="Left" Padding="13,0,13,0"
+                        Text="Modrinth 整合包下载" EventType="打开网页" EventData="https://modrinth.com/shaders" />
+            <local:MyButton Margin="0,4,20,0" Height="35" HorizontalAlignment="Left" Padding="13,0,13,0"
+                        Text="FTB 整合包下载" EventType="打开网页" EventData="https://feed-the-beast.com/modpacks" />
+        </StackPanel>
     </StackPanel>
 </local:MyCard>
 

--- a/启动器/角色皮肤导出.xaml
+++ b/启动器/角色皮肤导出.xaml
@@ -1,6 +1,4 @@
-<local:MyHint Margin="0,0,0,15" Text="该帮助页面还需要根据规范重新整理格式，优化排版与文案。如果你感兴趣也可以来帮帮忙！" IsWarn="False" />
-
-<local:MyCard Title="正版登录">
+<local:MyCard Title="正版账户" CanSwap="True" IsSwaped="True">
     <StackPanel Margin="25,40,23,15">
         <Grid>
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
@@ -21,7 +19,7 @@
     </StackPanel>
 </local:MyCard>
 
-<local:MyCard Title="离线及第三方登录">
+<local:MyCard Title="离线及第三方账户" CanSwap="True" IsSwaped="True">
     <StackPanel Margin="25,40,23,15">
         <Grid>
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"

--- a/帮助/提交帮助 - 编写规范.xaml
+++ b/帮助/提交帮助 - 编写规范.xaml
@@ -98,7 +98,9 @@
         <TextBlock Margin="0,0,0,4" LineHeight="17"
                     Text="7. 如图片需要详细注释，可以在图片链接末尾以参数 &quot;?comment=注释&quot; 为格式添加。" />
         <TextBlock Margin="0,0,0,4" LineHeight="17"
-                    Text="8. 若图片需要对应一段文字，请使用以下示例方案：" />
+                    Text="8. 如一张图片中涉及多个操作，请使用矩形框出各步骤并用箭头顺次连接。" />
+        <TextBlock Margin="0,0,0,4" LineHeight="17"
+                    Text="9. 如图片需要对应一段文字，请使用以下示例方案：" />
         <Grid>
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"
                         Text="在 PCL 中点击 &quot;下载&quot; 按钮，并选择左侧菜单 &quot;资源&quot; 分类下的 &quot;Mod&quot; 选项。" HorizontalAlignment="Left" />


### PR DESCRIPTION
### 前言
主要针对整合包安装、皮肤导出、光影安装页面进行了修改，对光影页面进行了全文重排版和重新措辞。做得比较赶，问题肯定超多，但苦逼高中生下周末才能开电脑解决出现的问题，抱歉orz！

### 内容
- 重写整合包安装页面中的 “安装已有压缩文件” 部分及其它冗余部分
- 帮助库图片规范中添加一条
- 导出皮肤页面中的 MyCard 默认折叠
- 大篇幅重制安装光影页面内容，重新排版、优化措辞并细化操作步骤、删减冗余内容。