### PR TITLE
修改Wiki链接

### DIFF
--- a/Minecraft/新手教程.json
+++ b/Minecraft/新手教程.json
@@ -6,5 +6,5 @@
 	"IsEvent": true,
 	"Keywords": "我的世界",
 	"EventType": "打开网页",
-	"EventData": "https://wiki.biligame.com/mc/%E6%95%99%E7%A8%8B"
+	"EventData": "https://zh.minecraft.wiki/w/%E6%95%99%E7%A8%8B"
 }


### PR DESCRIPTION
将“Minecraft 新手指南”链接指向迁移后的新站
（原先的新手教程链接由于wiki迁移与bwiki镜像站关闭，现已无法打开）