### PR TITLE
把BWiki给加回来？

### DIFF
--- a/百科/Minecraft BWiki
+++ b/百科/Minecraft BWiki
@@ -1,0 +1,9 @@
+{
+	"__Author__": "deep-dark-forest",
+	"Title": "原版百科（镜像）",
+	"Description": "Minecraft BWiki：Minecraft Wiki的镜像站，访问更快但更新较慢",
+	"Types": ["百科"],
+	"IsEvent": true,
+	"EventType": "打开网页",
+	"EventData": "https://wiki.biligame.com/mc/Minecraft_Wiki"
+}


### PR DESCRIPTION
[新Minecraft Wiki](https://minecraft.wiki)速度比之前的提升不少，但是在中国大陆仍然存在超时现象

<details>
<summary>测试截图</summary>

![image](https://github.com/LTCatt/PCL2Help/assets/131975043/daafbdf8-6927-414c-9a93-3357c496854e)

---
</details>

所以我建议把BWiki加回来，毕竟很多人打开外部链接都是靠启动器中的按钮
