### PR TITLE
修改 “提交帮助 - GitHub Desktop” 部分

### DIFF
--- a/帮助/提交帮助 - GitHub Desktop.json
+++ b/帮助/提交帮助 - GitHub Desktop.json
@@ -1,5 +1,5 @@
 {
-    "__Author__": "Not_Killer_233、龙腾猫跃",
+    "__Author__": "Not_Killer_233、龙腾猫跃、XiaoFans、wuyuncheng-26",
 	"Title": "使用 GitHub Desktop 获取帮助库",
 	"Description": "使用 GitHub Desktop 软件获取 PCL 帮助库并提交",
     "ShowInSearch": false

--- a/帮助/提交帮助 - GitHub Desktop.json
+++ b/帮助/提交帮助 - GitHub Desktop.json
@@ -1,5 +1,5 @@
 {
-    "__Author__": "Not_Killer_233、龙腾猫跃、XiaoFans、wuyuncheng-26",
+    "__Author__": "Not_Killer_233、龙腾猫跃、XiaoFans",
 	"Title": "使用 GitHub Desktop 获取帮助库",
 	"Description": "使用 GitHub Desktop 软件获取 PCL 帮助库并提交",
     "ShowInSearch": false

--- a/帮助/提交帮助 - GitHub Desktop.xaml
+++ b/帮助/提交帮助 - GitHub Desktop.xaml
@@ -5,7 +5,7 @@
         <TextBlock Margin="0,0,0,4" LineHeight="17"
                     Text="在开始前，请先根据下文中的 “第 1 部分：安装和身份验证” 完成对 GitHub Desktop 的安装与登录。"/>
         <local:MyListItem Margin="0,2,0,10" Logo="pack://application:,,,/images/Blocks/CommandBlock.png" SnapsToDevicePixels="True" Type="Clickable"
-                            Title="GitHub Desktop 使用入门" Info="GitHub 的官方教程文档页，根据其中的内容完成安装与登录即可" EventType="打开网页" EventData="https://docs.github.com/cn/desktop/installing-and-configuring-github-desktop/getting-started-with-github-desktop#part-1-installing-and-authenticating" />
+                            Title="GitHub Desktop 使用入门" Info="GitHub 的官方教程文档页，根据其中的内容完成安装与登录即可" EventType="打开网页" EventData="https://docs.github.com/zh/desktop/overview/getting-started-with-github-desktop#part-1-installing-and-authenticating" />
         <TextBlock Margin="0,10,0,4" LineHeight="17"
                     Text="点击下方按钮，进入 PCL 文件夹，创建名称为 Help 的文件夹。"/>
         <StackPanel Height="35" Margin="0,4,0,10" Orientation="Horizontal">
@@ -18,12 +18,12 @@
         <TextBlock Margin="0,0,0,4" LineHeight="17"
                     Text="使用你喜爱的编辑器编辑文件，并保存。"/>
         <TextBlock Margin="0,0,0,4" LineHeight="17"
-                    Text="在 GitHub Desktop 仓库界面左侧栏，找到你修改的文件，并在文件左侧的方框中选中(仅选中一个文件，如要选中多个文件，请在 Commit to main 按钮上方的文本框输入消息)。&#xa;在右侧的文件预览中确认无误后，单击 “Commit to main” (位于左侧栏的下方) "/>
+                    Text="在 GitHub Desktop 仓库界面左侧栏，找到你修改的文件，并在文件左侧的方框中选中(仅选中一个文件，如要选中多个文件，请在 “Commit to main” 按钮上方的文本框输入消息)。&#xa;在右侧的文件预览中确认无误后，单击 “Commit to main” (位于左侧栏的下方) "/>
         <TextBlock Margin="0,0,0,4" LineHeight="17"
                     Text="在所有文件均提交完毕后，按下 “Ctrl+P” 以推送至 GitHub。"/>
         <TextBlock Margin="0,0,0,4" LineHeight="17"
-                    Text="在窗口标题栏下方，选中 “Current branch”,再在子栏底部选择 “Choose a branch to merge into master” 以新建拉取请求。&#xa;选中 master 分支，并单击子窗口下方的蓝色按钮确认。"/>
+                    Text="在窗口标题栏下方，选中 “Current branch”，再在子栏底部选择 “Choose a branch to merge into master” 以新建拉取请求。&#xa;选中 master 分支，并单击子窗口下方的蓝色按钮确认。"/>
     </StackPanel>
 </local:MyCard>
 
-<local:MyHint Margin="0,0,0,15" Text="帮助作者：Not_Killer_233、龙腾猫跃、XiaoFans" IsWarn="False" />
+<local:MyHint Margin="0,0,0,15" Text="帮助作者：Not_Killer_233、龙腾猫跃、XiaoFans、wuyuncheng-26" IsWarn="False" />

--- a/帮助/提交帮助 - GitHub Desktop.xaml
+++ b/帮助/提交帮助 - GitHub Desktop.xaml
@@ -26,4 +26,4 @@
     </StackPanel>
 </local:MyCard>
 
-<local:MyHint Margin="0,0,0,15" Text="帮助作者：Not_Killer_233、龙腾猫跃、XiaoFans、wuyuncheng-26" IsWarn="False" />
+<local:MyHint Margin="0,0,0,15" Text="帮助作者：Not_Killer_233、龙腾猫跃、XiaoFans" IsWarn="False" />


### PR DESCRIPTION
第 8 行：
原链接 `https://docs.github.com/cn/desktop/installing-and-configuring-github-desktop/getting-started-with-github-desktop#part-1-installing-and-authenticating`
会被重定向至 `https://docs.github.com/zh/desktop/overview/getting-started-with-github-desktop#part-1-installing-and-authenticating`
其他的是一些符号问题