### PR TITLE
小型综合更新：Bug 修复与 UI 优化

### DIFF
--- a/Minecraft/数据包安装.xaml
+++ b/Minecraft/数据包安装.xaml
@@ -6,10 +6,12 @@
     <StackPanel Margin="25,40,23,15">
         <TextBlock TextWrapping="Wrap" Margin="0,0,0,4"
                    Text="你可以在许多相关资源网站找到数据包，诸如 Modrinth、Planet Minecraft 等。你可以点击下面的按钮来快速跳转至这些网站：" />
-        <local:MyButton Margin="0,4,20,0" Height="35" HorizontalAlignment="Left" Padding="13,0,13,0"
-                        Text="Modrinth 数据包下载" EventType="打开网页" EventData="https://modrinth.com/datapacks" />
-        <local:MyButton Margin="0,4,20,0" Height="35" HorizontalAlignment="Left" Padding="13,0,13,0"
-                        Text="Planet Minecraft 数据包下载" EventType="打开网页" EventData="https://www.planetminecraft.com/data-packs/" />
+	<StackPanel Orientation="Horizontal" HorizontalAlignment="Left">
+	        <local:MyButton Margin="0,4,20,0" Height="35" HorizontalAlignment="Left" Padding="13,0,13,0"
+	                        Text="Modrinth 数据包下载" EventType="打开网页" EventData="https://modrinth.com/datapacks" />
+	        <local:MyButton Margin="0,4,20,0" Height="35" HorizontalAlignment="Left" Padding="13,0,13,0"
+	                        Text="Planet Minecraft 数据包下载" EventType="打开网页" EventData="https://www.planetminecraft.com/data-packs/" />
+	</StackPanel>
     </StackPanel>
 </local:MyCard>
 

--- a/Minecraft/整合包安装.xaml
+++ b/Minecraft/整合包安装.xaml
@@ -9,7 +9,7 @@
             <local:MyButton Margin="0,4,20,0" Height="35" HorizontalAlignment="Left" Padding="13,0,13,0"
                         Text="CurseForge 整合包下载" EventType="打开网页" EventData="https://www.curseforge.com/minecraft/search?class=modpacks" />
             <local:MyButton Margin="0,4,20,0" Height="35" HorizontalAlignment="Left" Padding="13,0,13,0"
-                        Text="Modrinth 整合包下载" EventType="打开网页" EventData="https://modrinth.com/shaders" />
+                        Text="Modrinth 整合包下载" EventType="打开网页" EventData="https://modrinth.com/modpacks" />
         </StackPanel>
     </StackPanel>
 </local:MyCard>

--- a/帮助/提交帮助 - GitHub Desktop.xaml
+++ b/帮助/提交帮助 - GitHub Desktop.xaml
@@ -10,7 +10,7 @@
                     Text="点击下方按钮，进入 PCL 文件夹，创建名称为 Help 的文件夹。"/>
         <StackPanel Height="35" Margin="0,4,0,10" Orientation="Horizontal">
         <local:MyButton MinWidth="140" Padding="13,0" Margin="0,0,20,0" HorizontalAlignment="Left" ColorType="Highlight"
-                        Text="打开文件夹" EventType="打开文件" EventData="explorer.exe|/select,&quot;{path}&quot;" />
+                        Text="打开文件夹" EventType="打开文件" EventData="explorer.exe|&quot;{path}PCL&quot;" />
         </StackPanel>        
         <TextBlock Margin="0,0,0,4" LineHeight="17"
                     Text="打开你 Clone 的仓库的本地文件夹，在文件浏览器中，开启 “显示隐藏的项目” 选项以选中 .git 文件夹。&#xa;此后，将整个 PCL2Help 内的内容剪切到 PCL/Help 文件夹下。"/>

--- a/帮助/提交帮助 - GitHub Desktop.xaml
+++ b/帮助/提交帮助 - GitHub Desktop.xaml
@@ -10,7 +10,7 @@
                     Text="点击下方按钮，进入 PCL 文件夹，创建名称为 Help 的文件夹。"/>
         <StackPanel Height="35" Margin="0,4,0,10" Orientation="Horizontal">
         <local:MyButton MinWidth="140" Padding="13,0" Margin="0,0,20,0" HorizontalAlignment="Left" ColorType="Highlight"
-                        Text="打开文件夹" EventType="打开文件" EventData="explorer.exe|/select,Help" />
+                        Text="打开文件夹" EventType="打开文件" EventData="explorer.exe|/select,&quot;{path}&quot;" />
         </StackPanel>        
         <TextBlock Margin="0,0,0,4" LineHeight="17"
                     Text="打开你 Clone 的仓库的本地文件夹，在文件浏览器中，开启 “显示隐藏的项目” 选项以选中 .git 文件夹。&#xa;此后，将整个 PCL2Help 内的内容剪切到 PCL/Help 文件夹下。"/>


### PR DESCRIPTION
### :bug: Bug 相关
- 修复了安装整合包页面中 Modrinth 按钮打开了光影包网站的 Bug
![41c69f149368e4b051ac3b1b5a1cd581](https://github.com/user-attachments/assets/889856ba-c94b-47de-bd35-6556e9f9d19a)
- 修复了使用 GitHub Desktop 获取帮助库中打开 PCL 文件夹按钮的 Path 指向问题

### :art: UI 相关
- 微调了安装数据包页面中两个外站链接按钮的布局，现在统一是一行了