### PR TITLE
docs(minecraft&guide): fix tutorials related to exporting modpacks

### DIFF
--- a/Minecraft/导出整合包.xaml
+++ b/Minecraft/导出整合包.xaml
@@ -1,4 +1,4 @@
-<local:MyCard Title="自动导出整合包" Margin="0,0,0,15">
+<local:MyCard Title="导出整合包" Margin="0,0,0,15">
 	<StackPanel Margin="25,40,23,15">
 		<TextBlock TextWrapping="Wrap" Margin="0,0,0,4" LineHeight="17" 
                    Text="你可以使用 PCL 内置的整合包导出功能快捷地导出整合包并分发给你的朋友。" />
@@ -9,7 +9,7 @@
     </StackPanel>
 </local:MyCard>
 
-<local:MyCard Title="选择版本并自动导出" Margin="0,0,0,15" CanSwap="True" IsSwaped="True">
+<local:MyCard Title="选择版本并导出" Margin="0,0,0,15" CanSwap="True" IsSwaped="True">
 	<StackPanel Margin="25,40,23,15">
         <Grid>
             <TextBlock TextWrapping="Wrap" Margin="0,15,0,4" Width="200"

--- a/指南/整合包制作 - Public.xaml
+++ b/指南/整合包制作 - Public.xaml
@@ -6,6 +6,13 @@
     </StackPanel>
 </local:MyCard>
 
+<local:MyCard Title="导出整合包" CanSwap="True" IsSwaped="True">
+    <StackPanel Margin="25,40,23,11">
+        <local:MyListItem Margin="-5,0,-5,8"
+		                  EventType="打开帮助" EventData="Minecraft/导出整合包.json" />
+	</StackPanel>
+</local:MyCard>
+
 <local:MyCard Title="自动安装整合包" CanSwap="True" IsSwaped="True">
     <StackPanel Margin="25,40,23,11">
 	    <TextBlock Margin="0,0,0,4" LineHeight="17"

--- a/指南/整合包制作 - Snapshot.xaml
+++ b/指南/整合包制作 - Snapshot.xaml
@@ -8,7 +8,7 @@
     </StackPanel>
 </local:MyCard>
 
-<local:MyCard Title="自动导出整合包" CanSwap="True" IsSwaped="True">
+<local:MyCard Title="导出整合包" CanSwap="True" IsSwaped="True">
     <StackPanel Margin="25,40,23,11">
         <local:MyListItem Margin="-5,0,-5,8"
 		                  EventType="打开帮助" EventData="Minecraft/导出整合包.json" />


### PR DESCRIPTION
- Remove some ambiguous words (not cleaned up before)
- Fix tutorial for exporting modpacks not appearing in guide for public edition