### PR TITLE
PCL2Help/帮助/提交帮助 - Intellij Idea.xaml无法在pcl上面显示

### DIFF
--- a/帮助/提交帮助 - Intellij Idea.xaml
+++ b/帮助/提交帮助 - Intellij Idea.xaml
@@ -18,7 +18,7 @@
                     Text="1. 安装 Git Integration 插件。首先打开 IntelliJ IDEA，然后依次点击 “File” → “Settings” → “Plugins” ，在出现的搜索框内输入 “Git Integration” ，找到插件并进行安装。" />            
         
         <TextBlock Margin="0,0,0,4" LineHeight="17" 
-                    Text="2. 生成 SSH 公钥和私钥。打开 “Terminal”，并输入 "ssh-keygen -t rsa -C <你的邮箱>" 以生成 SSH 公钥和私钥，然后打开生成的 id_rsa.pub 文件，并复制文件中的内容。" />
+                    Text="2. 生成 SSH 公钥和私钥。打开 “Terminal”，并输入 “ssh-keygen -t rsa -C &lt;你的邮箱&gt;” 以生成 SSH 公钥和私钥，然后打开生成的 id_rsa.pub 文件，并复制文件中的内容。" />
         
         <TextBlock Margin="0,0,0,4" LineHeight="17" 
                     Text="3. 将 SSH 公钥添加到 GitHub。点击下面的 “访问设置” 按钮，然后在 GitHub 设置页面点击 “SSH and GPG keys”，接着点击 “New SSH Key”，最后在 “Key” 区域粘贴步骤2中复制的 SSH 公钥，并为其添加标题。" />  
@@ -33,9 +33,9 @@
 
           <StackPanel Height="35" Margin="0,4,0,10" Orientation="Horizontal">
                 <local:MyButton MinWidth="140" Padding="13,0" Margin="0,0,20,0" HorizontalAlignment="Left"
-                            Text="设置 Git 用户名" EventType="复制文本" EventData="git config --global user.name <你的名称> " />
+                            Text="设置 Git 用户名" EventType="复制文本" EventData="git config --global user.name &lt;你的名称&gt; " />
                 <local:MyButton MinWidth="140" Padding="13,0" Margin="0,0,20,0" HorizontalAlignment="Left"
-                            Text="设置 Git 邮箱" EventType="复制文本" EventData="git config --global user.email <你的邮箱> " />
+                            Text="设置 Git 邮箱" EventType="复制文本" EventData="git config --global user.email &lt;你的邮箱&gt; " />
           </StackPanel>
     </StackPanel>
 </local:MyCard>        
@@ -52,7 +52,7 @@
             <local:MyButton MinWidth="140" Padding="13,0" Margin="0,0,20,0" HorizontalAlignment="Left"
                         Text="git add ." EventType="复制文本" EventData="git add ." />
             <local:MyButton MinWidth="140" Padding="13,0" Margin="0,0,20,0" HorizontalAlignment="Left"
-                        Text="git commit -m <提交信息> " EventType="复制文本" EventData="git commit -m <提交信息> " />
+                        Text="git commit -m &lt;提交信息&gt; " EventType="复制文本" EventData="git commit -m &lt;提交信息&gt; " />
             <local:MyButton MinWidth="140" Padding="13,0" Margin="0,0,20,0" HorizontalAlignment="Left"
                         Text="git push" EventType="复制文本" EventData="git push" />
         </StackPanel>
@@ -69,4 +69,5 @@
 </local:MyCard> 
 
 <local:MyHint Margin="0,0,0,15" Text="作者：Ian-Rin、iammcjack6、龙腾猫跃、XiaoFans" IsWarn="False" />
+
 

--- a/帮助/提交帮助 - Intellij Idea.xaml
+++ b/帮助/提交帮助 - Intellij Idea.xaml
@@ -44,7 +44,7 @@
     <StackPanel Margin="25,40,23,15">
         <TextBlock Margin="0,5,0,4" LineHeight="17" Text="1. 克隆仓库到本地。打开 “Terminal”，输入 git clone https://github.com/LTCatt/PCL2Help.git ，此操作会在本地创建一个名为 “PCL2Help” 的文件夹，并将代码仓库的内容下载到这个文件夹。" />
 
-        <TextBlock Margin="0,5,0,4" LineHeight="17" Text="2. 使用 IntelliJ IDEA 进行编写。首先，在 “Terminal” 中输入 “cd PCL2Help” 切换到代码仓库目录，然后打开 IntelliJ IDEA，选择 "打开已有的项目"，选择刚刚下载的 “PCL2Help” 文件夹，编写代码并保存更改。" />
+        <TextBlock Margin="0,5,0,4" LineHeight="17" Text="2. 使用 IntelliJ IDEA 进行编写。首先，在 “Terminal” 中输入 “cd PCL2Help” 切换到代码仓库目录，然后打开 IntelliJ IDEA，选择 “打开已有的项目”，选择刚刚下载的 “PCL2Help” 文件夹，编写代码并保存更改。" />
 
         <TextBlock Margin="0,5,0,4" LineHeight="17" Text="3. 将更改提交到 GitHub。在 “Terminal” 中，运行以下三个命令，将新更改添加到暂存区，然后提交并推送到远程仓库。" />
 
@@ -69,5 +69,6 @@
 </local:MyCard> 
 
 <local:MyHint Margin="0,0,0,15" Text="作者：Ian-Rin、iammcjack6、龙腾猫跃、XiaoFans" IsWarn="False" />
+
 
 


### PR DESCRIPTION
[PCL2Help/帮助/提交帮助 - Intellij Idea.xaml](url)
<img width="729" height="259" alt="1" src="https://github.com/user-attachments/assets/d62fbabc-49a0-4f24-9830-59612164baf0" />
<img width="709" height="257" alt="2" src="https://github.com/user-attachments/assets/6da93b90-4bc6-4e56-8fc1-61df37fd43d7" />

25行
并输入 "ssh-keygen -t rsa -C <你的邮箱>" 以生成 SSH 公钥和私钥，然后打开生成的 id_rsa.pub 文件，并复制文件中的内容。" />
"ssh-keygen -t rsa -C <你的邮箱>"改成中文“ssh-keygen -t rsa -C <你的邮箱>”
 47行
<TextBlock Margin="0,5,0,4" LineHeight="17" Text="2. 使用 IntelliJ IDEA 进行编写。首先，在 “Terminal” 中输入 “cd PCL2Help” 切换到代码仓库目录，然后打开 IntelliJ IDEA，选择 "打开已有的项目"，选择刚刚下载的 “PCL2Help” 文件夹，编写代码并保存。 "打开已有的项目"修改为“打开已有的项目”

将21行<你的邮箱>改为&lt;你的邮箱&gt;
将36行<你的名称>改为&lt;你的名称&gt;
将38行<你的邮箱>改为&lt;你的邮箱&gt;
将55行<提交信息>改为&lt;提交信息&gt;